### PR TITLE
add getTemplate to locals

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "multiplex-templates": "^1.0",
     "nunjucks-filters": "^0.1.1",
     "vhost": "^3.0.0",
-    "winston": "^0.9.0"
+    "winston": "^0.9.0",
+    "glob": "^5.0.3"
   },
   "devDependencies": {
     "chai": "^2.1",
-    "glob": "^5.0.3",
     "mocha": "^2.2",
     "sinon": "^1.14"
   }

--- a/services/composer.test.js
+++ b/services/composer.test.js
@@ -1,0 +1,43 @@
+'use strict';
+var expect = require('chai').expect,
+  sinon = require('sinon'),
+  glob = require('glob'),
+  config = require('config'),
+  composer = require('./composer');
+
+describe('Composer', function () {
+  describe('getTemplate()', function () {
+    var sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(config, 'get').returns('template');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('throws error if no templates found', function () {
+      sandbox.stub(glob, 'sync').returns([]);
+      expect(function () {
+        return composer.getTemplate();
+      }).to.throw(Error);
+    });
+
+    it('gets a nunjucks template', function () {
+      sandbox.stub(glob, 'sync').returns(['template.nunjucks']);
+      expect(composer.getTemplate()).to.eql('template.nunjucks');
+    });
+
+    it('gets a jade template', function () {
+      sandbox.stub(glob, 'sync').returns(['template.jade']);
+      expect(composer.getTemplate()).to.eql('template.jade');
+    });
+
+    it('gets a mustache template', function () {
+      sandbox.stub(glob, 'sync').returns(['template.mustache']);
+      expect(composer.getTemplate()).to.eql('template.mustache');
+    });
+  });
+});


### PR DESCRIPTION
allows you to do this in your templates:

```
{{ embed(getTemplate('entrytext'), data) | safe }}
```

Or, in Jade:

``` jade
div != embed(getTemplate('entrytext'), data)
```
