### PR TITLE
add component routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9",
+    "body-parser": "^1.12",
     "config": "^1.12.0",
     "express": "^4.12.2",
     "js-yaml": "^3.2.7",


### PR DESCRIPTION
Hook up component routes:

``` js
function addComponentRoutes(router) {
  router.use(bodyParser.json());

  router.get('/components', notImplemented);
  router.get('/components/:name', getRouteTypically);
  router.put('/components/:name', putRouteTypically);
  router.get('/components/:name/instances', notImplemented);
  router.get('/components/:name/instances/:id', getRouteTypically);
  router.put('/components/:name/instances/:id', putRouteTypically);
}
```
