### PR TITLE
Separate layout from instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^3.5",
     "memdown": "^1.0.0",
     "multiplex-templates": "^1.0",
-    "nunjucks-filters": "^0.1.1",
+    "nunjucks-filters": "^1.0",
     "vhost": "^3.0.0",
     "winston": "^0.9"
   },


### PR DESCRIPTION
Allow the use of the baseTemplate keyword to override the default starting place of rendering templates.  This allows reusable "layouts", where the data begins in a later child template.

``` yaml

---
  story:
    instances:
      vulture-first:
        baseTemplate: generic-article-layout
        title: When clouds attack
        author: Cirrocumulus
        components:
          -
            _ref: /components/text/instances/0
          -
            _ref: /components/image/instances/0
      vulture-second:
        baseTemplate: generic-article-layout
        title: How to on how tos
        author: Joy
        components:
          -
            _ref: /components/text/instances/0
          -
            _ref: /components/image/instances/0
```

Example of a layout:

``` jade
doctype html
html(lang="en")
  head
    title=title
  body
    main
      p This is a Homepage Two-column Layout component.
      div!= embed(state.getTemplate('index'), state, state)
```
