### PR TITLE
push generic functionality to lodash-ny-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "js-yaml": "^3.2.7",
     "levelup": "^0.19",
     "lodash": "^3.5",
+    "lodash-ny-util": "^0.1.0",
     "memdown": "^1.0.0",
     "multiplex-templates": "^1.0",
     "nunjucks-filters": "^1.0",

--- a/services/schema.js
+++ b/services/schema.js
@@ -6,6 +6,8 @@ var fs = require('fs'),
   db = require('./db'),
   bluebird = require('bluebird');
 
+_.mixin(require('lodash-ny-util'));
+
 /**
  * Takes a url path, and returns the component name within it.
  * @param {string} path
@@ -28,27 +30,6 @@ function isComponent(obj) {
 }
 
 /**
- * @param obj
- * @param filter
- *
- * NOTE:  Should probably put this in our lodash utils
- */
-function listDeepObjects(obj, filter) {
-  var cursor, items,
-    list = [],
-    queue = [obj];
-
-  while(queue.length) {
-    cursor = queue.pop();
-    items = _.filter(cursor, _.isObject);
-    list = list.concat(_.filter(items, filter || _.identity));
-    queue = queue.concat(items);
-  }
-
-  return list;
-}
-
-/**
  * Get a single schema from a specific directory (maybe including those in node_modules??)
  * @param {string} dir
  * @returns {{}}
@@ -66,7 +47,7 @@ function getSchemaComponents(dir) {
   var schema = getSchema(dir);
 
   if (schema) {
-    return listDeepObjects(schema, isComponent);
+    return _.listDeepObjects(schema, isComponent);
   } else {
     return null;
   }
@@ -77,7 +58,7 @@ function getSchemaComponents(dir) {
  */
 function resolveDataReferences(data) {
   var referenceProperty = '_ref',
-    placeholders = listDeepObjects(data, referenceProperty);
+    placeholders = _.listDeepObjects(data, referenceProperty);
 
   return bluebird.all(placeholders).each(function (placeholder) {
     return db.get(placeholder[referenceProperty]).then(JSON.parse).then(function (obj) {
@@ -91,7 +72,6 @@ function resolveDataReferences(data) {
 
 module.exports.isComponent = isComponent;
 module.exports.getComponentNameFromPath = getComponentNameFromPath;
-module.exports.listDeepObjects = listDeepObjects;
 module.exports.getSchema = getSchema;
 module.exports.getSchemaComponents = getSchemaComponents;
 module.exports.resolveDataReferences = resolveDataReferences;

--- a/services/schema.test.js
+++ b/services/schema.test.js
@@ -68,27 +68,6 @@ describe('schema', function () {
     ]);
   });
 
-  it('listDeepObjects gets all deep objects', function () {
-    var result = schema.listDeepObjects({a:{b:{c:{d:"e"}}, f:{g:{h:"e"}}}});
-
-    expect(result).to.have.length(5);
-  });
-
-  it('listDeepObjects can filter by existence of properties', function () {
-    var result = schema.listDeepObjects({a:{b:{c:{d:"e"}}, f:{d:{g:"e"}}}}, "d");
-
-    expect(result).to.have.length(2);
-  });
-
-  it('listDeepObjects can filter by component', function () {
-    var result = schema.listDeepObjects({a: {_type:'yarn'}, b: {c: {_type:'sweater'}}}, schema.isComponent);
-
-    expect(result).to.deep.equal([
-      {_type:'yarn'},
-      {_type:'sweater'}
-    ]);
-  });
-
   it('resolveDataReferences looks up references', function (done) {
     var mock,
       data = {


### PR DESCRIPTION
Pull some generic functionality that's really useful to https://github.com/nymag/lodash-ny-util/pull/6 instead, so we can use it in more packages.
