### PR TITLE
sites define routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,5 @@ var express = require('express'),
   app = express();
 
 module.exports = function () {
-  //add routes
-  routes(app);
-
-  // pass all route handlers into the composer
-  app.use(composer);
-
-  return app;
+  return routes(app);
 };

--- a/services/routes.js
+++ b/services/routes.js
@@ -183,10 +183,11 @@ module.exports = function (app) {
       // add support for site.setLayout sugar
       siteRouter.setLayout = setLayout;
 
-      // add the routes for that site's path
-      hostMiddleware.use(site.path, require(siteController)(siteRouter));
       // add res.locals.site (slug) to every request
       hostMiddleware.use(site.path, addSiteLocals(site.slug));
+      // add the routes for that site's path
+      hostMiddleware.use(site.path, require(siteController)(siteRouter, composer));
+
 
       addComponentRoutes(hostMiddleware);
     });
@@ -194,4 +195,5 @@ module.exports = function (app) {
     // once all sites are added, wrap them in a vhost
     app.use(vhost(envHost, hostMiddleware));
   });
+  return app;
 };


### PR DESCRIPTION
Sites define routes, no assumptions about always using composer for all routes (like images, css, js, etc.)

``` js
module.exports = function (site, composer) {
  site.get('/', composer);
  site.get('/:year/:month/:name', composer);

  return site;
};
```
