### PR TITLE
add list ability

### DIFF
--- a/services/references.js
+++ b/services/references.js
@@ -14,7 +14,8 @@ var config = require('config'),
   path = require('path'),
   glob = require('glob'),
   bluebird = require('bluebird'),
-  assertions = require('./assertions');
+  assertions = require('./assertions'),
+  log = require('./log');
 
 /**
  *
@@ -71,6 +72,47 @@ function putComponentData(ref, data) {
 }
 
 /**
+ * List instances within a component
+ * @param {string} ref
+ * @returns {ReadStream}
+ */
+function listComponentInstances(ref) {
+  assertions.exists(ref, 'reference');
+  var componentName = schema.getComponentNameFromPath(ref);
+  assertions.exists(componentName, 'component name', ref);
+
+  return db.list({prefix: path, values: false, isArray: false})
+    .on('error', function (error) {
+      log.warn('listComponentInstances::error', path, error);
+    });
+}
+
+/**
+ * Check component module for list function, otherwise list instances within a component
+ * @param {string} ref
+ * @param {object} [locals]
+ * @returns {*}
+ */
+function listComponentData(ref, locals) {
+  var result,
+    componentName = schema.getComponentNameFromPath(ref),
+    componentModule = files.getComponentModule(componentName);
+
+  //assertions
+  assertions.exists(ref, 'reference');
+  assertions.exists(componentName, 'component name', ref);
+
+  if (componentModule && _.isFunction(componentModule.list)) {
+    result = componentModule.list(ref, locals);
+  } else {
+    // default back to db.js, (db takes strings, not objects)
+    result = listComponentInstances(ref);
+  }
+
+  return result;
+}
+
+/**
  *
  * @param {string} ref
  */
@@ -117,7 +159,11 @@ function getTemplate(ref) {
   return possibleTemplates[0];
 }
 
+
+
 module.exports.getComponentData = getComponentData;
 module.exports.putComponentData = putComponentData;
+module.exports.listComponentData = listComponentData;
+module.exports.listComponentInstances = listComponentInstances;
 module.exports.getSchema = getSchema;
 module.exports.getTemplate = getTemplate;

--- a/services/schema.js
+++ b/services/schema.js
@@ -39,7 +39,16 @@ function isPromise(obj) {
  * If the object has `._type` as a string, we assume its a component
  */
 function isComponent(obj) {
-  return _.isString(obj._type);
+  return _.isObject(obj) && _.isString(obj._type);
+}
+
+/**
+ * Duck-typing.
+ *
+ * If the object has `.pipe` as a function, we assume its a pipeable stream
+ */
+function isPipeableStream(obj) {
+  return _.isObject(obj) && _.isFunction(obj.pipe);
 }
 
 /**
@@ -85,6 +94,7 @@ function resolveDataReferences(data) {
 
 module.exports.isPromise = isPromise;
 module.exports.isComponent = isComponent;
+module.exports.isPipeableStream = isPipeableStream;
 module.exports.getComponentNameFromPath = getComponentNameFromPath;
 module.exports.getSchema = getSchema;
 module.exports.getSchemaComponents = getSchemaComponents;

--- a/services/streams/json-transform.js
+++ b/services/streams/json-transform.js
@@ -1,0 +1,82 @@
+/**
+ * Transforms chunks of strings or objects into JSON-parseable text
+ *
+ * @module
+ */
+
+'use strict';
+
+var util = require('util'),
+  Transform = require('stream').Transform;
+
+function JSONTransform(options) {
+  // allow use without new
+  if (!(this instanceof JSONTransform)) {
+    return new JSONTransform(options);
+  }
+
+  this.isFirst = true;
+
+  if (options.objectMode !== true) {
+    //assume that if they're not giving us objects, this will be an array of strings
+    this.isArray = true;
+  } else {
+    //otherwise they either tell us, or we're assuming they want the smallest form of this data, which is an object.
+    this.isArray = options.isArray || false;
+  }
+
+  this.options = options;
+  this.keyProperty = options.keyProperty || 'key';
+  this.valueProperty = options.valueProperty || 'value';
+
+  // init Transform
+  Transform.call(this, options);
+}
+util.inherits(JSONTransform, Transform);
+JSONTransform.prototype._transform = function (chunk, enc, cb) {
+  var item, error,
+    isArray = this.isArray,
+    objectMode = this.options.objectMode;
+
+  if (!objectMode && isArray) {
+    //if not an object, assume an array of strings.
+    item = '"' + chunk.toString() + '"';
+  } else if (objectMode && isArray) {
+    //if objects and array, concat the chunks
+    item = JSON.stringify(chunk);
+  } else if (objectMode && !isArray) {
+    //if objects and not an array, give it in object format (not array)
+    item = '"' + chunk[this.keyProperty] + '":' + JSON.stringify(chunk[this.valueProperty]);
+  } else {
+    error = new Error('Unknown option configuration');
+  }
+
+  if (this.isFirst) {
+    //only the first time
+    this.isFirst = false;
+    if (isArray) {
+      item = '[' + item;
+    } else {
+      item = '{' + item;
+    }
+  } else {
+    item = ',' + item;
+  }
+
+  if (error) {
+    this.emit('error', error);
+  } else {
+    this.push(item);
+  }
+  cb();
+};
+JSONTransform.prototype._flush = function (cb) {
+  if (this.isArray) {
+    this.push(']');
+  } else {
+    this.push('}');
+  }
+  cb();
+};
+
+module.exports = JSONTransform;


### PR DESCRIPTION
Add the ability to return lists.

`/components/:name` gets the "base" component.

`/components/:name/instances/:id` gets that "instance" component.

`/components/:name/instances` gets a list of instances in this component.

In server.js, they can use a `module.exports.list` to override this behavior.

In db.js, they can use db.list to return a range of keys, and optionally their values, as a stream.

`db.list({prefix: '/components/whatever/instances'})`  gets a json array of component instances.

`db.list({prefix: '/components/whatever/instances', values: true})` gets a json object with all instances with their values. 

`db.list({prefix: '/components/whatever/instances', values: true, isArray: true})` gets a json array with all instances with their values. 

We can now do ranges of leveldb values, but that's as far as it goes.  There is no search or query functionality.  At best, we could iterate through _all_ elements and filter the ones we don't want.

We should probably leave functionality like "most-popular" and "top-stories" to server.js with db.js events like:

``` js
db.on('put', function (key, value) {
  //check if it's being published, and if its date is newer than the list we have already?
});
```
