### PR TITLE
add lists/ endpoint

### DIFF
--- a/services/controllers/lists.js
+++ b/services/controllers/lists.js
@@ -1,0 +1,34 @@
+/**
+ * Controller for URIs
+ *
+ * @module
+ */
+
+'use strict';
+
+var _ = require('lodash'),
+  responses = require('../responses');
+
+/**
+ * @param req
+ * @param res
+ * @param next
+ */
+function onlyJSONLists(req, res, next) {
+  if (req.body && !_.isArray(req.body)) {
+    responses.clientError(new Error('Only accepts lists.'), res);
+  } else {
+    next();
+  }
+}
+
+function routes(router) {
+  router.get('/', responses.listAllWithPrefix);
+  router.get('/:name', responses.getRouteFromDB);
+  router.use('/:name', onlyJSONLists);
+  router.put('/:name', responses.putRouteFromDB);
+  router.post('/', responses.notImplemented);
+}
+
+module.exports = routes;
+module.exports.onlyJSONLists = onlyJSONLists;

--- a/services/controllers/lists.test.js
+++ b/services/controllers/lists.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var _ = require('lodash'),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  lib = require('./' + filename),
+  responses = require('../responses'),
+  sinon = require('sinon'),
+  log = require('../log');
+
+
+
+describe(filename, function () {
+  var sandbox;
+
+  function createMockReq() {
+    return {};
+  }
+
+  function createMockRes() {
+    return {};
+  }
+
+  /**
+   * Fail unit test immediately with message;
+   * @param {string} msg
+   * @param {string} [actual]
+   * @param {string} [expected]
+   * @param {string} [operator]
+   */
+  function fail(msg, actual, expected, operator) {
+    require('chai').assert.fail(actual, expected, msg, operator);
+  }
+
+  /**
+   * Shortcut
+   */
+  function expectNoLogging() {
+    var logExpectations = sandbox.mock(log);
+    logExpectations.expects('info').never();
+    logExpectations.expects('warn').never();
+    logExpectations.expects('error').never();
+  }
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('onlyJSONLists', function () {
+    var fn = lib[this.title];
+
+    it('allows undefined body', function (done) {
+      var req = createMockReq(),
+        res = createMockRes();
+
+      expectNoLogging();
+      sandbox.mock(responses).expects('clientError').never();
+
+      fn(req, res, function () {
+        done();
+      });
+
+      sandbox.verify();
+    });
+
+    it('allows array body', function (done) {
+      var req = createMockReq(),
+        res = createMockRes();
+
+      expectNoLogging();
+      req.body = [];
+      sandbox.mock(responses).expects('clientError').never();
+
+      fn(req, res, function () {
+        done();
+      });
+
+      sandbox.verify();
+    });
+
+    it('error when req.body is object', function () {
+      var req = createMockReq(),
+        res = createMockRes();
+
+      expectNoLogging();
+      req.body = {};
+      sandbox.mock(responses).expects('clientError').once();
+
+      fn(req, res, function () {
+        fail('next() should not be called.');
+      });
+
+      sandbox.verify();
+    });
+  });
+});

--- a/services/files.js
+++ b/services/files.js
@@ -22,7 +22,7 @@ function getFiles(dir) {
   try {
     return fs.readdirSync(dir)
       .filter(function (file) {
-        return !fs.statSync(path.join(dir, file)).isDirectory();
+        return !fs.statSync(path.join(dir, file)).isDirectory() && file.indexOf('.test.') === -1;
       });
   } catch (ex) {
     return [];

--- a/services/responses.js
+++ b/services/responses.js
@@ -133,6 +133,33 @@ function serverError(err, res) {
   });
 }
 
+/**
+ * All server errors should look like this.
+ *
+ * In general, 500s represent a _developer mistake_.  We should try to replace them with more descriptive errors.
+ * @param {Error} err
+ * @param res
+ */
+function clientError(err, res) {
+  res.status(400).format({
+    json: function () {
+      //send the message as well
+      res.send({
+        message: err.message,
+        code: 400
+      });
+    },
+    html: function () {
+      //send some html (should probably be some default, or a render of a 500 page).
+      res.send('400 Client Error: ' + err.message);
+    },
+    'default': function () {
+      //send whatever is default for this type of data with this status code.
+      res.sendStatus(400);
+    }
+  });
+}
+
 function handleError(res) {
   return function (err) {
     if ((err.name === 'NotFoundError') ||
@@ -216,7 +243,7 @@ function getRouteFromDB(req, res) {
  */
 function putRouteFromDB(req, res) {
   expectJSON(function () {
-    return db.put(normalizePath(req.baseUrl + req.url), JSON.stringify(req.body));
+    return db.put(normalizePath(req.baseUrl + req.url), JSON.stringify(req.body)).return(req.body);
   }, res);
 }
 
@@ -227,7 +254,8 @@ module.exports.normalizePath = normalizePath;
 module.exports.getUniqueId = getUniqueId;
 
 //error responses
-module.exports.notFound = notFound; //404
+module.exports.clientError = clientError; //400 client error
+module.exports.notFound = notFound; //404 not found
 module.exports.notImplemented = notImplemented; //nice 500
 module.exports.serverError = serverError; //bad 500
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var glob = require('glob'),
   _ = require('lodash'),
-  tests = glob.sync(__dirname + '/../services/*.test.js');
+  tests = glob.sync(__dirname + '/../services/**/*.test.js');
 
 _.map(tests, function (test) {
   require(test);


### PR DESCRIPTION
Add `lists/` endpoint that only accepts arrays / lists.

Also gives us the ability to unit tests controllers with `*.test.js` without interfering with the loading of controllers.

Issue https://github.com/nymag/byline/issues/55
