### PR TITLE
Generic beforeEachTest in API tests

### DIFF
--- a/test/api/components/all.js
+++ b/test/api/components/all.js
@@ -1,0 +1,26 @@
+/**
+ * Shared by all HTTP methods in the current API.
+ */
+
+'use strict';
+
+var apiAccepts = require('../../fixtures/api-accepts');
+
+/**
+ * Repopulate the DB before each test.
+ * @param sandbox
+ * @param hostname
+ * @param data
+ * @returns {Promise}
+ */
+module.exports.beforeEachTest = function beforeEachTest(sandbox, hostname, data) {
+  return apiAccepts.beforeEachTest({
+    sandbox: sandbox,
+    hostname: hostname,
+    pathsAndData: {
+      '/components/valid': data,
+      '/components/valid/instances/valid': data,
+      '/components/valid/instances/valid@valid': data
+    }
+  });
+};

--- a/test/api/components/delete.js
+++ b/test/api/components/delete.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -21,7 +22,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachComponentTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/components/get.js
+++ b/test/api/components/get.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -16,7 +17,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachComponentTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/components/post.js
+++ b/test/api/components/post.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -16,7 +17,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachComponentTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -19,7 +20,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachComponentTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/lists/all.js
+++ b/test/api/lists/all.js
@@ -1,0 +1,22 @@
+/**
+ * Shared by all HTTP methods in the current API.
+ */
+
+'use strict';
+
+var apiAccepts = require('../../fixtures/api-accepts');
+
+/**
+ * Repopulate the DB before each test.
+ * @param sandbox
+ * @param hostname
+ * @param data
+ * @returns {Promise}
+ */
+module.exports.beforeEachTest = function (sandbox, hostname, data) {
+  return apiAccepts.beforeEachTest({
+    sandbox: sandbox,
+    hostname: hostname,
+    pathsAndData: {'/lists/valid': data}
+  });
+};

--- a/test/api/lists/get.js
+++ b/test/api/lists/get.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.')[0]),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -16,7 +17,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachListTest(sandbox, hostname, data); //Does beforeEach need to be specific to each route?
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/lists/put.js
+++ b/test/api/lists/put.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.')[0]),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -17,7 +18,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachUriTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox, hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/pages/all.js
+++ b/test/api/pages/all.js
@@ -1,0 +1,33 @@
+/**
+ * Shared by all HTTP methods in the current API.
+ */
+
+'use strict';
+
+var apiAccepts = require('../../fixtures/api-accepts');
+
+/**
+ * Repopulate the DB before each test.
+ * @param sandbox
+ * @param hostname
+ * @param pageData
+ * @param layoutData
+ * @param componentData
+ * @returns {Promise}
+ */
+module.exports.beforeEachTest = function (sandbox, hostname, pageData, layoutData, componentData) {
+  return apiAccepts.beforeEachTest({
+    sandbox: sandbox,
+    hostname: hostname,
+    pathsAndData: {
+      '/components/layout': layoutData,
+      '/components/layout@valid': layoutData,
+      '/components/valid': {deep: {_ref: '/components/validDeep'}},
+      '/components/valid@valid': {deep: {_ref: '/components/validDeep'}},
+      '/components/validDeep': componentData,
+      '/components/validDeep@valid': componentData,
+      '/pages/valid': pageData,
+      '/pages/valid@valid': pageData
+    }
+  });
+};

--- a/test/api/pages/get.js
+++ b/test/api/pages/get.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -18,7 +19,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachPageTest(sandbox,  hostname, pageData, layoutData, componentData);
+      return beforeEachTest(sandbox,  hostname, pageData, layoutData, componentData);
     });
 
     afterEach(function () {

--- a/test/api/pages/put.js
+++ b/test/api/pages/put.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -19,7 +20,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachPageTest(sandbox,  hostname, pageData, layoutData, componentData);
+      return beforeEachTest(sandbox,  hostname, pageData, layoutData, componentData);
     });
 
     afterEach(function () {

--- a/test/api/uris/all.js
+++ b/test/api/uris/all.js
@@ -1,0 +1,29 @@
+/**
+ * Shared by all HTTP methods in the current API.
+ */
+
+'use strict';
+
+var apiAccepts = require('../../fixtures/api-accepts');
+
+/**
+ * Repopulate the DB before each test.
+ * @param sandbox
+ * @param hostname
+ * @param data
+ * @returns {Promise}
+ */
+module.exports.beforeEachTest = function (sandbox, hostname, data) {
+  return apiAccepts.beforeEachTest({
+    sandbox: sandbox,
+    hostname: hostname,
+    pathsAndData: {
+      '/components/valid': data,
+      '/components/valid/instances/valid': data,
+      '/components/valid/instances/valid@valid': data,
+      '/pages/valid': data,
+      '/pages/valid@valid': data,
+      '/uris/valid': data
+    }
+  });
+};

--- a/test/api/uris/get.js
+++ b/test/api/uris/get.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -16,7 +17,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachUriTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox,  hostname, data);
     });
 
     afterEach(function () {

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  beforeEachTest = require('./all').beforeEachTest;
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -17,7 +18,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      return apiAccepts.beforeEachUriTest(sandbox,  hostname, data);
+      return beforeEachTest(sandbox,  hostname, data);
     });
 
     afterEach(function () {

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -256,125 +256,30 @@ function beforeTesting(suite, hostname, data) {
 
 /**
  * Before each test, make the DB and Host consistent, and get a _new_ version of express.
+ * Generic, often called by all.js.
  *
  * Yes, brand new, for every single test.
  *
- * @param sandbox
- * @param hostname
- * @param data
+ * @param {Object} options
+ * @param {Object} options.sandbox
+ * @param {String} options.hostname
+ * @param {Object} options.pathsAndData E.g. `{'path/one': data1, 'path/two': data2}`
  * @returns {Promise}
  */
-function beforeEachComponentTest(sandbox, hostname, data) {
+function beforeEachTest(options) {
   app = express();
-  host = hostname;
-  stubFiles(sandbox);
-  stubSchema(sandbox);
-  stubGetTemplate(sandbox);
-  stubMultiplexRender(sandbox);
-  stubLogging(sandbox);
-  routes.addHost(app, hostname);
+  host = options.hostname;
+  stubFiles(options.sandbox);
+  stubSchema(options.sandbox);
+  stubGetTemplate(options.sandbox);
+  stubMultiplexRender(options.sandbox);
+  stubLogging(options.sandbox);
+  routes.addHost(app, options.hostname);
 
   return db.clear().then(function () {
-    return bluebird.all([
-      db.put('/components/valid', JSON.stringify(data)),
-      db.put('/components/valid/instances/valid', JSON.stringify(data)),
-      db.put('/components/valid/instances/valid@valid', JSON.stringify(data))
-    ]);
-  });
-}
-
-/**
- * Before each test, make the DB and Host consistent, and get a _new_ version of express.
- *
- * Yes, brand new, for every single test.
- *
- * @param sandbox
- * @param hostname
- * @param pageData
- * @param layoutData
- * @param componentData
- * @returns {Promise}
- */
-function beforeEachPageTest(sandbox, hostname, pageData, layoutData, componentData) {
-  app = express();
-  host = hostname;
-  stubFiles(sandbox);
-  stubSchema(sandbox);
-  stubGetTemplate(sandbox);
-  stubMultiplexRender(sandbox);
-  stubLogging(sandbox);
-  routes.addHost(app, hostname);
-
-  return db.clear().then(function () {
-    return bluebird.all([
-      db.put('/components/layout', JSON.stringify(layoutData)),
-      db.put('/components/layout@valid', JSON.stringify(layoutData)),
-      db.put('/components/valid', JSON.stringify({deep: {_ref: '/components/validDeep'}})),
-      db.put('/components/valid@valid', JSON.stringify({deep: {_ref: '/components/validDeep'}})),
-      db.put('/components/validDeep', JSON.stringify(componentData)),
-      db.put('/components/validDeep@valid', JSON.stringify(componentData)),
-      db.put('/pages/valid', JSON.stringify(pageData)),
-      db.put('/pages/valid@valid', JSON.stringify(pageData))
-    ]);
-  });
-}
-
-/**
- * Before each test, make the DB and Host consistent, and get a _new_ version of express.
- *
- * Yes, brand new, for every single test.
- *
- * @param sandbox
- * @param hostname
- * @param data
- * @returns {Promise}
- */
-function beforeEachUriTest(sandbox, hostname, data) {
-  app = express();
-  host = hostname;
-  stubFiles(sandbox);
-  stubSchema(sandbox);
-  stubGetTemplate(sandbox);
-  stubMultiplexRender(sandbox);
-  stubLogging(sandbox);
-  routes.addHost(app, hostname);
-
-  return db.clear().then(function () {
-    return bluebird.all([
-      db.put('/components/valid', JSON.stringify(data)),
-      db.put('/components/valid/instances/valid', JSON.stringify(data)),
-      db.put('/components/valid/instances/valid@valid', JSON.stringify(data)),
-      db.put('/pages/valid', JSON.stringify(data)),
-      db.put('/pages/valid@valid', JSON.stringify(data)),
-      db.put('/uris/valid', JSON.stringify(data))
-    ]);
-  });
-}
-
-/**
- * Before each test, make the DB and Host consistent, and get a _new_ version of express.
- *
- * Yes, brand new, for every single test.
- *
- * @param sandbox
- * @param hostname
- * @param data
- * @returns {Promise}
- */
-function beforeEachListTest(sandbox, hostname, data) {
-  app = express();
-  host = hostname;
-  stubFiles(sandbox);
-  stubSchema(sandbox);
-  stubGetTemplate(sandbox);
-  stubMultiplexRender(sandbox);
-  stubLogging(sandbox);
-  routes.addHost(app, hostname);
-
-  return db.clear().then(function () {
-    return bluebird.all([
-      db.put('/lists/valid', JSON.stringify(data))
-    ]);
+    return bluebird.all(_.map(options.pathsAndData, function(data, path) {
+      return db.put(path, JSON.stringify(data));
+    }));
   });
 }
 
@@ -388,7 +293,4 @@ module.exports.updatesOther = updatesOther;
 module.exports.createsNewVersion = createsNewVersion;
 module.exports.stubComponentPath = stubSchema;
 module.exports.beforeTesting = beforeTesting;
-module.exports.beforeEachComponentTest = beforeEachComponentTest;
-module.exports.beforeEachPageTest = beforeEachPageTest;
-module.exports.beforeEachUriTest = beforeEachUriTest;
-module.exports.beforeEachListTest = beforeEachListTest;
+module.exports.beforeEachTest = beforeEachTest;


### PR DESCRIPTION
The idea here is to keep the `test/fixtures/api-accepts.js` generic and move the specific cases of `beforeEachTest` into an `all.js` file within each api test folder. This way the DB data setup is defined within each of the specific API's and can be shared by all of the HTTP method tests for the API.
