### PR TITLE
fix uri quotes

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -115,7 +115,7 @@ function methodNotAllowed(options) {
 
 /**
  * This route not allowed
- * @param {[string]} options
+ * @param {{accept: [string]}} options
  */
 function notAcceptable(options) {
   var acceptableTypes = options && options.accept || [];
@@ -230,6 +230,20 @@ function acceptJSONOnly(req, res, next) {
 }
 
 /**
+ * Reusable code to return Text data, both for good results AND errors.
+ *
+ * Captures and hides appropriate errors.
+ *
+ * @param {function} fn
+ * @param res
+ */
+function expectText(fn, res) {
+  bluebird.try(fn).then(function (result) {
+    res.send(result);
+  }).catch(handleError(res));
+}
+
+/**
  * Reusable code to return JSON data, both for good results AND errors.
  *
  * Captures and hides appropriate errors.
@@ -337,6 +351,7 @@ module.exports.varyWithoutExtension = varyWithoutExtension; //adds Vary header w
 module.exports.onlyCachePublished = onlyCachePublished; //adds cache control when published or not
 module.exports.handleError = handleError; //404 or 500 based on exception
 module.exports.acceptJSONOnly = acceptJSONOnly; //406 on non-JSON body
+module.exports.expectText = expectText;
 module.exports.expectJSON = expectJSON;
 module.exports.expectHTML = expectHTML;
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -68,7 +68,8 @@ function addControllerRoutes(router) {
   var routesPath = '/routes';
 
   //assume json for anything in request bodies
-  router.use(require('body-parser').json());
+  router.use(require('body-parser').json({strict: true, type: 'application/json'}));
+  router.use(require('body-parser').text({type: 'text/*'}));
 
   //load all controller routers
   _.each(files.getFiles(__dirname + routesPath), function (filename) {

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -43,7 +43,7 @@ let validation = _.bindAll({
     isType = accepts.indexOf(type) !== -1;
 
     if (!isAll && !isType) {
-      responses.notAcceptable({accept: [type]})(req, res);
+      responses.notAcceptable({accept: [type]})(req, res, next);
     } else {
       req.headers.accept = type;
       next();

--- a/lib/routes/uris.js
+++ b/lib/routes/uris.js
@@ -14,7 +14,7 @@ var responses = require('../responses'),
  * @param res
  */
 function getUriFromReference(req, res) {
-  responses.expectJSON(function () {
+  responses.expectText(function () {
     return db.get(responses.normalizePath(req.baseUrl + req.url));
   }, res);
 }
@@ -24,7 +24,7 @@ function getUriFromReference(req, res) {
  * @param res
  */
 function putUriFromReference(req, res) {
-  responses.expectJSON(function () {
+  responses.expectText(function () {
     return db.put(responses.normalizePath(req.baseUrl + req.url), req.body).return(req.body);
   }, res);
 }
@@ -32,10 +32,11 @@ function putUriFromReference(req, res) {
 function routes(router) {
   router.use(responses.varyWithoutExtension({varyBy: ['Accept']}));
 
-  router.all('*', responses.acceptJSONOnly);
   router.all('/', responses.methodNotAllowed({allow: ['get']}));
+  router.all('/', responses.notAcceptable({accept: ['application/json']}));
   router.get('/', responses.list());
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name', responses.notAcceptable({accept: ['text/plain']}));
   router.get('/:name', getUriFromReference);
   router.put('/:name', putUriFromReference);
   router.post('/', responses.notImplemented);

--- a/test/api/uris/get.js
+++ b/test/api/uris/get.js
@@ -12,7 +12,8 @@ describe(endpointName, function () {
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      data = { name: 'Manny', species: 'cat' };
+      acceptsText = apiAccepts.acceptsText(_.camelCase(filename)),
+      data = 'mock uri';
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
@@ -26,19 +27,24 @@ describe(endpointName, function () {
     describe('/uris', function () {
       var path = this.title;
       acceptsJson(path, {}, 200, '["/uris/valid"]');
-      acceptsHtml(path, {}, 406);
+      acceptsHtml(path, {}, 406, '406 text/html not acceptable');
+      acceptsText(path, {}, 406, 'Not Acceptable');
     });
 
     describe('/uris/:name', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 200, '"{\\"name\\":\\"Manny\\",\\"species\\":\\"cat\\"}"');
-      acceptsJson(path, {name: 'missing'}, 404);
+      acceptsJson(path, {name: 'invalid'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/plain'] });
+      acceptsJson(path, {name: 'valid'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/plain'] });
+      acceptsJson(path, {name: 'missing'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/plain'] });
 
-      acceptsHtml(path, {name: 'invalid'}, 406);
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
+      acceptsHtml(path, {name: 'invalid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+
+      acceptsText(path, {name: 'invalid'}, 404, 'Not Found');
+      acceptsText(path, {name: 'valid'}, 200, data);
+      acceptsText(path, {name: 'missing'}, 404, 'Not Found');
     });
   });
 });

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -13,7 +13,9 @@ describe(endpointName, function () {
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      data = { name: 'Manny', species: 'cat' };
+      acceptsTextBody = apiAccepts.acceptsTextBody(_.camelCase(filename)),
+      acceptsText = apiAccepts.acceptsText(_.camelCase(filename)),
+      data = 'mock data';
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
@@ -29,20 +31,24 @@ describe(endpointName, function () {
 
       acceptsJson(path, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
       acceptsJsonBody(path, {}, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-      acceptsHtml(path, {}, 406);
+      acceptsHtml(path, {}, 405, '405 Method PUT not allowed');
+      acceptsText(path, {}, 405, 'Method Not Allowed');
     });
 
     describe('/uris/:name', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'valid'}, 200, {});
-      acceptsJson(path, {name: 'missing'}, 200, {});
+      acceptsJson(path, {name: 'valid'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/plain'] });
+      acceptsJson(path, {name: 'missing'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/plain'] });
 
-      acceptsJsonBody(path, {name: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing'}, data, 200, data);
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
 
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
+      acceptsText(path, {name: 'valid'}, 200, '');
+      acceptsText(path, {name: 'missing'}, 200, '');
+
+      acceptsTextBody(path, {name: 'valid'}, data, 200, data);
+      acceptsTextBody(path, {name: 'missing'}, data, 200, data);
     });
   });
 });

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -129,6 +129,47 @@ function acceptsJson(method) {
   };
 }
 
+/**
+ * Create a generic test that accepts JSON with a BODY
+ * @param method
+ * @returns {Function}
+ */
+function acceptsTextBody(method) {
+  return function (path, replacements, body, status, data) {
+    createTest({
+      description: JSON.stringify(replacements) + ' accepts text with body ' + body,
+      path: path,
+      method: method,
+      replacements: replacements,
+      body: body,
+      data: data,
+      status: status,
+      accept: 'text/plain',
+      contentType: /text/
+    });
+  };
+}
+
+/**
+ * Create a generic test that accepts JSON
+ * @param {String} method
+ * @returns {Function}
+ */
+function acceptsText(method) {
+  return function (path, replacements, status, data) {
+    createTest({
+      description: JSON.stringify(replacements) + ' accepts text',
+      path: path,
+      method: method,
+      replacements: replacements,
+      data: data,
+      status: status,
+      accept: 'text/plain',
+      contentType: /text/
+    });
+  };
+}
+
 function updatesOther(method) {
   return function (path, otherPath, replacements, data) {
     var realPath = getRealPath(replacements, path),
@@ -312,7 +353,12 @@ function beforeEachTest(options) {
 
   return db.clear().then(function () {
     return bluebird.all(_.map(options.pathsAndData, function(data, path) {
-      return db.put(path, JSON.stringify(data));
+
+      if (typeof data === 'object') {
+        data = JSON.stringify(data);
+      }
+
+      return db.put(path, data);
     }));
   });
 }
@@ -417,6 +463,8 @@ module.exports.setHost = setHost;
 module.exports.acceptsHtml = acceptsHtml;
 module.exports.acceptsJson = acceptsJson;
 module.exports.acceptsJsonBody = acceptsJsonBody;
+module.exports.acceptsText = acceptsText;
+module.exports.acceptsTextBody = acceptsTextBody;
 module.exports.updatesOther = updatesOther;
 module.exports.createsNewVersion = createsNewVersion;
 module.exports.cascades = cascades;


### PR DESCRIPTION
The uri endpoint was returning URIs in quotes for some reason, because they were being treated as JSON.  Now we treat URI data as `text/plain`.
