### PR TITLE
allow post components

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -110,6 +110,16 @@ let route = _.bindAll({
   },
 
   /**
+   * @param req
+   * @param res
+   */
+  post: function (req, res) {
+    responses.expectJSON(function () {
+      return controller.post(responses.normalizePath(req.baseUrl + req.url), req.body);
+    }, res);
+  },
+
+  /**
    * Change the acceptance type based on the extension they gave us
    *
    * Fail if they don't accept right protocol and not *
@@ -171,8 +181,9 @@ function routes(router) {
   router.delete('/:name', route.del);
 
   router.all('/:name/instances', responses.acceptJSONOnly);
-  router.all('/:name/instances', responses.methodNotAllowed({allow: ['get']}));
+  router.all('/:name/instances', responses.methodNotAllowed({allow: ['get', 'post']}));
   router.get('/:name/instances', responses.listWithoutVersions());
+  router.post('/:name/instances', route.post);
   router.get('/:name/instances/:id.:ext', validation.onlyAcceptExtension);
   router.get('/:name/instances/:id.:ext', route.extension);
 

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -203,9 +203,6 @@ function cascadingPut(ref, data) {
  * @param {string} ref
  */
 function del(ref) {
-
-
-  //get old values, so we can return them when the thing is deleted.
   return get(ref).then(function (oldData) {
     var promise,
       componentModule = files.getComponentModule(getName(ref));
@@ -217,6 +214,19 @@ function del(ref) {
     }
 
     return promise.return(oldData);
+  });
+}
+
+/**
+ * @param {string} ref
+ * @param {object} data
+ * @returns {Promise.object}
+ */
+function post(ref, data) {
+  ref += '/' + uid();
+  return cascadingPut(ref, data).then(function (result) {
+    result._ref = ref;
+    return result;
   });
 }
 
@@ -276,6 +286,7 @@ function getTemplate(ref) {
 module.exports.get = get;
 module.exports.put = cascadingPut; //special: could lead to multiple put operations
 module.exports.del = del;
+module.exports.post = post;
 
 //maybe server.js people want to reach in and reuse these?
 module.exports.putLatest = putLatest;

--- a/test/api/components/delete.js
+++ b/test/api/components/delete.js
@@ -62,8 +62,8 @@ describe(endpointName, function () {
       var path = this.title;
 
       acceptsJson(path, {name: 'invalid'}, 404, { message: 'Not Found', code: 404 });
-      acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method DELETE not allowed' });
-      acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method DELETE not allowed' });
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'post'], code: 405, message: 'Method DELETE not allowed' });
+      acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'post'], code: 405, message: 'Method DELETE not allowed' });
 
       acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');

--- a/test/api/components/post.js
+++ b/test/api/components/post.js
@@ -11,7 +11,9 @@ describe(endpointName, function () {
     var sandbox,
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      expectDataPlusRef = apiAccepts.expectDataPlusRef,
       data = { name: 'Manny', species: 'cat' };
 
     beforeEach(function () {
@@ -32,49 +34,53 @@ describe(endpointName, function () {
     describe('/components/:name', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'invalid'}, 404, { message: "Not Found", code: 404 });
       acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
       acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
 
-      acceptsHtml(path, {name: 'invalid'}, 404);
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
     });
 
     describe('/components/:name/schema', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'invalid'}, 404, { message: 'Not Found', code: 404 });
       acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method POST not allowed' });
       acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method POST not allowed' });
 
-      acceptsHtml(path, {name: 'invalid'}, 404);
-      acceptsHtml(path, {name: 'valid'}, 405);
-      acceptsHtml(path, {name: 'missing'}, 405);
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 405, '405 Method POST not allowed');
+      acceptsHtml(path, {name: 'missing'}, 405, '405 Method POST not allowed');
     });
 
     describe('/components/:name/instances', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method POST not allowed' });
-      acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method POST not allowed' });
+      acceptsJson(path, {name: 'invalid'}, 404, { message: 'Not Found', code: 404 });
+      acceptsJson(path, {name: 'valid'}, 200, expectDataPlusRef({}));
+      acceptsJson(path, {name: 'missing'}, 200, expectDataPlusRef({}));
 
-      acceptsHtml(path, {name: 'invalid'}, 404);
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
+      acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { message: 'Not Found', code: 404 });
+      acceptsJsonBody(path, {name: 'valid'}, data, 200, expectDataPlusRef(data));
+      acceptsJsonBody(path, {name: 'missing'}, data, 200, expectDataPlusRef(data));
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
     });
 
     describe('/components/:name/instances/:id', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { message: 'Not Found', code: 404 });
       acceptsJson(path, {name: 'valid', id: 'valid'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
       acceptsJson(path, {name: 'valid', id: 'missing'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
 
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406, '406 text/html not acceptable');
     });
   });
 });

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -93,12 +93,12 @@ describe(endpointName, function () {
       var path = this.title;
 
       acceptsJson(path, {name: 'invalid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
 
       acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid'}, data, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJsonBody(path, {name: 'missing'}, data, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {name: 'valid'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {name: 'missing'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
 
       acceptsHtml(path, {name: 'invalid'}, 404);
       acceptsHtml(path, {name: 'valid'}, 406);

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -4,7 +4,6 @@ var _ = require('lodash'),
   express = require('express'),
   request = require('supertest-as-promised'),
   files = require('../../lib/files'),
-  fs = require('fs'),
   components = require('../../lib/services/components'),
   routes = require('../../lib/routes'),
   db = require('../../lib/services/db'),
@@ -266,6 +265,19 @@ function cascades(method) {
   };
 }
 
+/**
+ * Expect the data, plus some reference.
+ * @param {object} data
+ * @returns {Function}
+ */
+function expectDataPlusRef(data) {
+  return function (res) {
+    expect(res.body._ref.length > 0).to.equal(true);
+    delete res.body._ref;
+    expect(res.body).to.deep.equal(data);
+  };
+}
+
 function setApp(value) {
   app = value;
 }
@@ -352,7 +364,7 @@ function beforeEachTest(options) {
   routes.addHost(app, options.hostname);
 
   return db.clear().then(function () {
-    return bluebird.all(_.map(options.pathsAndData, function(data, path) {
+    return bluebird.all(_.map(options.pathsAndData, function (data, path) {
 
       if (typeof data === 'object') {
         data = JSON.stringify(data);
@@ -468,7 +480,7 @@ module.exports.acceptsTextBody = acceptsTextBody;
 module.exports.updatesOther = updatesOther;
 module.exports.createsNewVersion = createsNewVersion;
 module.exports.cascades = cascades;
-module.exports.stubComponentPath = stubSchema;
+module.exports.expectDataPlusRef = expectDataPlusRef;
 module.exports.beforeTesting = beforeTesting;
 module.exports.beforeEachComponentTest = beforeEachComponentTest;
 module.exports.beforeEachPageTest = beforeEachPageTest;


### PR DESCRIPTION
Allow POSTing something to `/components/text/instances` something like this:

``` json
{"hey":"you"}
```

which returns

``` json
{
    "hey": "you",
    "_ref": "/components/text/instances/U4IwHPRAAAA="
}
```

and when you get `/components/text/instances/U4IwHPRAAAA=`, you see:

``` json
{
   "hey": "you"
}
```
