### PR TITLE
propagating publishing

### DIFF
--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -11,8 +11,8 @@ var _ = require('lodash'),
   uid = require('../uid'),
   files = require('../files'),
   schema = require('../schema'),
+  references = require('./references'),
   bluebird = require('bluebird'),
-  is = require('../assert-is'),
   path = require('path'),
   config = require('config'),
   glob = require('glob'),
@@ -162,38 +162,68 @@ function isReferencedAndReal(obj) {
 }
 
 /**
- * @param {string} ref
- * @param {object} data
- * @returns {Promise.object}
+ * If the ref has a version that is "propagating" like @published or @latest, replace all versions in the data
+ *  with the new version.
+ * @param ref
+ * @param data
  */
-function cascadingPut(ref, data) {
+function replacePropagatingVersions(ref, data) {
+  var version = ref.split('@')[1];
+  if (references.isPropagatingVersion(ref)) {
+    references.replaceAllVersions(version)(data);
+  }
+}
+
+function splitCascadingData(ref, data) {
+  var ops, list;
+
   //search for _ref with _size greater than 1
-  var ops = [],
-    deepObjects = _.listDeepObjects(data, isReferencedAndReal);
-
-  //reverse; children should be before parents
-  _.each(deepObjects.reverse(), function (obj) {
-    var ref = obj[referenceProperty];
-
-    // since children are before parents, no one will see data below them
-    ops.push({key: ref, value: _.omit(obj, referenceProperty)});
+  list = _.listDeepObjects(data, isReferencedAndReal);
+  ops = _.map(list.reverse(), function (obj) {
+    var ref = obj[referenceProperty],
+      // since children are before parents, no one will see data below them
+      op = {key: ref, value: _.omit(obj, referenceProperty)};
 
     // omit cloned 1 level deep and we clear what omit cloned from obj
     //  so the op gets the first level of data, but it's removed from the main obj
     clearOwnProperties(obj);
     obj[referenceProperty] = ref;
+
+    return op;
   });
 
   //add the cleaned root object at the end
   ops.push({key: ref, value: data});
 
+  return ops;
+}
+
+/**
+ * @param {string} ref
+ * @param {object} data
+ * @returns {Promise}
+ */
+function cascadingPut(ref, data) {
+  var ops;
+
+  //potentially propagate version throughout object
+  replacePropagatingVersions(ref, data);
+
+  //split data into pieces
+  ops = splitCascadingData(ref, data);
+
   return bluebird.map(ops, function (op) {
     //run each through the normal put, which may or may not hit custom component logic
     return put(op.key, op.value);
   }).then(function (ops) {
-    //flatten to list of final batch ops
-    return db.batch(_.filter(_.flattenDeep(ops), _.identity));
-  }).return(data); //return root object if successful
+    ops = _.filter(_.flattenDeep(ops), _.identity);
+    //flatten to list of final batch ops; return ops if successful
+    return db.batch(ops).return(ops);
+  }).then(function (ops) {
+    //return the value of the last batch operation (the root object) if successful
+    var rootOp = _.last(ops);
+    return rootOp && JSON.parse(rootOp.value);
+  });
 }
 
 /**

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -143,7 +143,7 @@ describe(_.startCase(filename), function () {
         data = {};
 
       sandbox.stub(files, 'getComponentModule');
-      sandbox.stub(db, 'batch');
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
 
       return fn(ref, data).then(function () {
         expect(db.batch.getCall(0).args[0]).to.deep.contain.members([{ key: 'a', type: 'put', value: '{}' }]);
@@ -155,7 +155,7 @@ describe(_.startCase(filename), function () {
         data = {};
 
       sandbox.stub(files, 'getComponentModule');
-      sandbox.stub(db, 'batch');
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
 
       return fn(ref, data).then(function (result) {
         expect(result).to.deep.equal({});
@@ -167,7 +167,7 @@ describe(_.startCase(filename), function () {
         data = {a: 'b', c: {_ref:'d', e: 'f'}};
 
       sandbox.stub(files, 'getComponentModule');
-      sandbox.stub(db, 'batch');
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
 
       return fn(ref, data).then(function () {
         var ops = db.batch.getCall(0).args[0];
@@ -186,7 +186,7 @@ describe(_.startCase(filename), function () {
         putSpy = sinon.stub();
 
       sandbox.stub(files, 'getComponentModule').returns({put: putSpy});
-      sandbox.stub(db, 'batch');
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
       putSpy.withArgs('a', sinon.match.object).returns([rootModuleData]);
       putSpy.withArgs('d', sinon.match.object).returns([deepModuleData]);
 
@@ -200,7 +200,7 @@ describe(_.startCase(filename), function () {
         data = {a: 'b', c: {_ref:'d', e: 'f'}};
 
       sandbox.stub(files, 'getComponentModule');
-      sandbox.stub(db, 'batch');
+      sandbox.stub(db, 'batch').returns(bluebird.resolve([]));
 
       return fn(ref, data).then(function (result) {
         expect(result).to.deep.equal({ a: 'b', c: { _ref: 'd' } });

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -1,6 +1,11 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = require('lodash'),
+  propagatingVersions = ['published', 'latest'];
+
+function setPropagatingVersions(value) {
+  propagatingVersions = value;
+}
 
 function replaceVersion(ref, version) {
   if (version) {
@@ -22,5 +27,15 @@ function replaceAllVersions(version) {
   };
 }
 
+/**
+ * Some versions should propagate throughout the rest of the data.
+ */
+function isPropagatingVersion(ref) {
+  var version = ref.split('@')[1];
+  return version && _.contains(propagatingVersions, version);
+}
+
 module.exports.replaceVersion = replaceVersion;
 module.exports.replaceAllVersions = replaceAllVersions;
+module.exports.setPropagatingVersions = setPropagatingVersions;
+module.exports.isPropagatingVersion = isPropagatingVersion;

--- a/test/api/components/post.js
+++ b/test/api/components/post.js
@@ -34,7 +34,7 @@ describe(endpointName, function () {
     describe('/components/:name', function () {
       var path = this.title;
 
-      acceptsJson(path, {name: 'invalid'}, 404, { message: "Not Found", code: 404 });
+      acceptsJson(path, {name: 'invalid'}, 404, { message: 'Not Found', code: 404 });
       acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
       acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
 

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -18,8 +18,15 @@ describe(endpointName, function () {
       cascades = apiAccepts.cascades(_.camelCase(filename)),
       data = { name: 'Manny', species: 'cat' },
       cascadingTarget = '/components/validDeep',
-      cascadingData = {a: 'b', c: {_ref: cascadingTarget, d: 'e'}},
-      cascadingReturnData = {a: 'b', c: {_ref: cascadingTarget}},
+      cascadingVersionedTarget = function (version) {
+        return cascadingTarget + (version ? '@' + version : '');
+      },
+      cascadingData = function (version) {
+        return {a: 'b', c: {_ref: cascadingVersionedTarget(version), d: 'e'}};
+      },
+      cascadingReturnData = function (version) {
+        return {a: 'b', c: {_ref: cascadingVersionedTarget(version)}};
+      },
       cascadingDeepData = {d: 'e'};
 
     beforeEach(function () {
@@ -49,13 +56,13 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
       acceptsJsonBody(path, {name: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData, 200, cascadingReturnData);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
 
       acceptsHtml(path, {name: 'invalid'}, 404);
       acceptsHtml(path, {name: 'valid'}, 406);
       acceptsHtml(path, {name: 'missing'}, 406);
 
-      cascades(path, {name: 'valid'}, cascadingData, cascadingTarget, cascadingDeepData);
+      cascades(path, {name: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
     });
 
     describe('/components/:name/schema', function () {
@@ -71,22 +78,23 @@ describe(endpointName, function () {
     });
 
     describe('/components/:name@:version', function () {
-      var path = this.title;
+      var path = this.title,
+        version = 'def';
 
-      acceptsJson(path, {name: 'invalid', version: 'def'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', version: 'def'}, 200, {});
-      acceptsJson(path, {name: 'missing', version: 'def'}, 200, {});
+      acceptsJson(path, {name: 'invalid', version: version}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', version: version}, 200, {});
+      acceptsJson(path, {name: 'missing', version: version}, 200, {});
 
-      acceptsJsonBody(path, {name: 'invalid', version: 'def'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', version: 'def'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', version: 'def'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version: 'def'}, cascadingData, 200, cascadingReturnData);
+      acceptsJsonBody(path, {name: 'invalid', version: version}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', version: version}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', version: version}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version: version}, cascadingData(), 200, cascadingReturnData());
 
-      acceptsHtml(path, {name: 'invalid', version: 'def'}, 404);
-      acceptsHtml(path, {name: 'valid', version: 'def'}, 406);
-      acceptsHtml(path, {name: 'missing', version: 'def'}, 406);
+      acceptsHtml(path, {name: 'invalid', version: version}, 404);
+      acceptsHtml(path, {name: 'valid', version: version}, 406);
+      acceptsHtml(path, {name: 'missing', version: version}, 406);
 
-      cascades(path, {name: 'valid', version: 'def'}, cascadingData, cascadingTarget, cascadingDeepData);
+      cascades(path, {name: 'valid', version: version}, cascadingData(), cascadingTarget, cascadingDeepData);
     });
 
     describe('/components/:name/instances', function () {
@@ -115,13 +123,13 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData, 200, cascadingReturnData);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
 
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
       acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
 
-      cascades(path, {name: 'valid', id: 'valid'}, cascadingData, cascadingTarget, cascadingDeepData);
+      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
 
       updatesOther(path, path + '@latest', {name: 'valid', id: 'newId'}, data);
       updatesOther(path + '@latest', path, {name: 'valid', id: 'newId'}, data);
@@ -132,22 +140,35 @@ describe(endpointName, function () {
     });
 
     describe('/components/:name/instances/:id@:version', function () {
-      var path = this.title;
+      var path = this.title,
+        version = 'def';
 
-      acceptsJson(path, {name: 'invalid', version: 'def', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', version: 'def', id: 'valid'}, 200, {});
-      acceptsJson(path, {name: 'valid', version: 'def', id: 'missing'}, 200, {});
+      acceptsJson(path, {name: 'invalid', version: version, id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', version: version, id: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'valid', version: version, id: 'missing'}, 200, {});
 
-      acceptsJsonBody(path, {name: 'invalid', version: 'def', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', version: 'def', id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', version: 'def', id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version: 'def', id: 'valid'}, cascadingData, 200, cascadingReturnData);
+      acceptsJsonBody(path, {name: 'invalid', version: version, id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', version: version, id: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(), 200, cascadingReturnData());
 
-      acceptsHtml(path, {name: 'invalid', version: 'def', id: 'valid'}, 404);
-      acceptsHtml(path, {name: 'valid', version: 'def', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', version: 'def', id: 'missing'}, 406);
+      acceptsHtml(path, {name: 'invalid', version: version, id: 'valid'}, 404);
+      acceptsHtml(path, {name: 'valid', version: version, id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', version: version, id: 'missing'}, 406);
 
-      cascades(path, {name: 'valid', version: 'def', id: 'valid'}, cascadingData, cascadingTarget, cascadingDeepData);
+      cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      //published version
+      version = 'published';
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
+      cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), cascadingVersionedTarget(version), cascadingDeepData);
+
+      //latest version
+      version = 'latest';
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
+      cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), cascadingVersionedTarget(version), cascadingDeepData);
     });
   });
 });

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -278,6 +278,34 @@ function expectDataPlusRef(data) {
   };
 }
 
+/**
+ * Expect all references in returned data to be @published
+ * @returns {Function}
+ */
+function expectAllRefsArePublished() {
+  return function (res) {
+    var data = res.body,
+      refs = _.listDeepObjects(data, '_ref');
+    _.each(refs, function (ref) {
+      expect(ref.indexOf('@published') > -1).to.equal(true);
+    });
+  };
+}
+
+/**
+ * All _refs are in objects with a size of one.
+ * @returns {Function}
+ */
+function expectCleanReferences() {
+  return function (res) {
+    var data = res.body,
+      refs = _.listDeepObjects(data, '_ref');
+    _.each(refs, function (obj) {
+      expect(_.size(obj)).to.equal(1);
+    });
+  };
+}
+
 function setApp(value) {
   app = value;
 }
@@ -480,6 +508,8 @@ module.exports.acceptsTextBody = acceptsTextBody;
 module.exports.updatesOther = updatesOther;
 module.exports.createsNewVersion = createsNewVersion;
 module.exports.cascades = cascades;
+module.exports.expectAllRefsArePublished = expectAllRefsArePublished;
+module.exports.expectCleanReferences = expectCleanReferences;
 module.exports.expectDataPlusRef = expectDataPlusRef;
 module.exports.beforeTesting = beforeTesting;
 module.exports.beforeEachComponentTest = beforeEachComponentTest;


### PR DESCRIPTION
When PUTing to `components/text/instances/test@published`:

`{"hey":"you","so":{"_ref":"/components/text/instances/what","heya":"again"}}`

then it returns: 

``` json
{
    "hey": "you",
    "so": {
        "_ref": "/components/text/instances/what@published"
    }
}
```

and when you GET `/components/text/instances/what@published` you receive:

``` json
{
   "heya": "again"
}
```

Notice how the published version propagates into the cascaded item.
