### PR TITLE
fix bad name get

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -119,6 +119,9 @@ function tryRequire(name, paths) {
     try {
       result = require(path);
     } catch (ex) {
+      if (ex.message && !ex.message.match(/Cannot find module/i)) {
+        throw ex;
+      }
       result = false;
     }
     return result;

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -38,7 +38,8 @@ function getName(ref) {
  */
 function get(ref, locals) {
   var promise,
-    componentModule = files.getComponentModule(getName(ref));
+    name = getName(ref),
+    componentModule = name && files.getComponentModule(name);
 
   if (_.isFunction(componentModule)) {
     promise = componentModule(ref, locals);

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -217,6 +217,12 @@ describe(_.startCase(filename), function () {
       return fn('/components/whatever');
     });
 
+    it('gets even with bad name', function () {
+      sandbox.stub(db, 'get').returns(bluebird.resolve('{}'));
+      sandbox.stub(files, 'getComponentModule').withArgs('whatever').returns(null);
+      return fn('bad name');
+    });
+
     it('gets using component module', function () {
       sandbox.stub(files, 'getComponentModule').returns(_.constant(bluebird.resolve()));
       return fn('/components/whatever');


### PR DESCRIPTION
When there was a badly named component, the `tryRequire` function didn't report the error (and still 404ed).

Also, when certain errors occurred, it blocked normal db fetching.

Both have been fixed, plus one test.

@yoshokatana @gloddy @cruzanmo 
