### PR TITLE
support scoped npm component names

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -10,7 +10,8 @@
 
 var _ = require('lodash'),
   fs = require('fs'),
-  path = require('path');
+  path = require('path'),
+  pkg = require(path.resolve('package.json'));
 
 /**
  *
@@ -56,11 +57,40 @@ function getFolders(dir) {
  * @return {[]}
  */
 function getComponents() {
-  var npmComponents = getFolders(path.resolve('node_modules')).filter(function (name) {
-    return _.contains(name, 'byline-');
-  });
+  var deps = pkg.dependencies,
+    npmComponents = _(deps).map(function (version, name) {
+      return _.contains(name, 'byline-') && name;
+    }).compact().value();
 
   return getFolders(path.resolve('components')).concat(npmComponents);
+}
+
+/**
+ * get a component name, so we can look it up in the file system
+ * internal components and regular npm components should quickly return their names
+ * scoped npm components will return the fully-scoped name
+ * @param {string} name
+ * @returns {string|null}
+ */
+function getComponentName(name) {
+  var allComponents = exports.getComponents(),
+    i = 0,
+    l = allComponents.length;
+
+  if (_.contains(allComponents, name)) {
+    // do a quick check for the component, return quickly if found
+    return name;
+  } else {
+    // the component might be a scoped npm module, do a slower deep check
+    for (; i < l; i++) {
+      if (_.contains(allComponents[i], name)) {
+        return allComponents[i];
+      }
+    }
+
+    // no matches?
+    return null;
+  }
 }
 
 /**
@@ -69,8 +99,10 @@ function getComponents() {
  * @return {string}
  */
 function getComponentPath(name) {
-  // make sure it's a component we have (either in components or node_modules)
-  if (!_.contains(exports.getComponents(), name)) {
+  var fullName = getComponentName(name);
+
+  // make sure it's a component we have (either in /components or package.json)
+  if (!getComponentName(name)) {
     /**
      * Cannot memoize an exception.
      *
@@ -78,31 +110,11 @@ function getComponentPath(name) {
      * we should not throw an exception.
      */
     return null;
-  } else if (fs.existsSync(path.resolve('components', name))) {
-    return path.resolve('components', name);
-  } else if (fs.existsSync(path.resolve('node_modules', name))) {
-    return path.resolve('node_modules', name);
+  } else if (fs.existsSync(path.resolve('components', fullName))) {
+    return path.resolve('components', fullName);
+  } else if (fs.existsSync(path.resolve('node_modules', fullName))) {
+    return path.resolve('node_modules', fullName);
   }
-}
-
-/**
- * get component name from path
- * @param  {string} filePath
- * @return {string}
- */
-function getComponentName(filePath) {
-  var nmFolder = 'node_modules' + path.sep,
-    cFolder = 'components' + path.sep,
-    parentFolder;
-
-  if (_.contains(filePath, nmFolder)) {
-    parentFolder = nmFolder;
-  } else if (_.contains(filePath, cFolder)) {
-    parentFolder = cFolder;
-  }
-
-  // get the next folder after the parent folder, e.g. node_modules/<get this>/foo/bar.css
-  return filePath.split(parentFolder)[1].split(path.sep)[0];
 }
 
 /**
@@ -154,3 +166,11 @@ exports.getFolders = _.memoize(getFolders);
 exports.getComponents = _.memoize(getComponents);
 exports.getComponentPath = _.memoize(getComponentPath); // memoize by _first_ parameter only (default)
 exports.getComponentModule = _.memoize(getComponentModule); // memoize by _first_ parameter only (default)
+
+// for testing
+/**
+ * @param {object} newPkg
+ */
+exports.usePackage = function (newPkg) {
+  pkg = newPkg;
+};

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -5,7 +5,8 @@ var _ = require('lodash'),
   sinon = require('sinon'),
   fs = require('fs'),
   path = require('path'),
-  files = require('./' + filename);
+  files = require('./' + filename),
+  pkg = require('../test/fixtures/config/package.json');
 
 describe(_.startCase(filename), function () {
   var dirStub, statStub, resolveStub, sandbox;
@@ -47,14 +48,12 @@ describe(_.startCase(filename), function () {
   describe('getComponents', function () {
     it('gets a list of components', function () {
       dirStub.withArgs('components').returns(['c1', 'c2']);
-      dirStub.withArgs('node_modules').returns(['byline-c3', 'byline-c4']);
       statStub.withArgs('components/c1').returns(createMockStat({isDirectory: true}));
       statStub.withArgs('components/c2').returns(createMockStat({isDirectory: false}));
-      statStub.withArgs('node_modules/byline-c3').returns(createMockStat({isDirectory: true}));
-      statStub.withArgs('node_modules/byline-c4').returns(createMockStat({isDirectory: false}));
       resolveStub.returnsArg(0);
+      files.usePackage(pkg);
 
-      expect(files.getComponents()).to.contain('c1', 'c2', 'byline-c3', 'byline-c4');
+      expect(files.getComponents()).to.contain('c1', 'c2', 'byline-c3', 'byline-c4', 'byline-c5');
     });
   });
 });

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -288,6 +288,7 @@ function getSchema(ref) {
  */
 function getPossibleTemplates(ref) {
   var filePath = files.getComponentPath(ref);
+
   if (_.isString(filePath)) {
     if (_.contains(filePath, 'node_modules')) {
       return [path.join(filePath, require(filePath + '/package.json').template)];

--- a/test/fixtures/config/package.json
+++ b/test/fixtures/config/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@nymdev/byline-editor": "v1.1.1",
+    "byline-c3": "v1.1.1",
+    "byline-c4": "v1.1.1"
+  }
+}


### PR DESCRIPTION
- `files.getComponents()` now looks in your `package.json` to grab npm components (rather than `node_modules`
- added `getComponentName()` to resolve component names
- updated `files. getComponentPath()` to use the resolved component names
