### PR TITLE
Allow setting of db that levelup uses.

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -156,3 +156,7 @@ module.exports.clear = function () {
 module.exports.getDB = function () {
   return db;
 };
+
+module.exports.setDB = function (value) {
+  db = value;
+};


### PR DESCRIPTION
Allow developers to use any levelUP adapter that they want, such as:
- https://github.com/hmalphettes/redisdown
- https://github.com/fritzy/levelup-riak
- https://github.com/MakoLabs/level-dynamodb
