### PR TITLE
pass through params in state.locals

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -235,6 +235,16 @@ function setUriRouteHandlers(routes) {
 }
 
 /**
+ * add params to res.locals
+ * @param {object} req
+ * @param {object} res
+ * @returns {object}
+ */
+function addParams(req, res) {
+  return _.assign(res.locals, req.params);
+}
+
+/**
  * Run composer by translating url to a "page" by base64ing it.  Errors are handled by Express.
  *
  * NOTE: Does not return a promise ON PURPOSE.  This function is express-style.
@@ -246,6 +256,8 @@ function setUriRouteHandlers(routes) {
 function composer(req, res, next) {
   var urlWithoutQuerystring = req.url.split('?').shift(),
     pageReference = '/uris/' + new Buffer(req.vhost.hostname + urlWithoutQuerystring).toString('base64');
+
+  addParams(req, res);
 
   renderUri(pageReference, res)
     .then(function (html) {


### PR DESCRIPTION
This allows us to reference the params we set up in our site routes, e.g.

``` js
site.get('/', composer);
site.get('/tags/:tag', composer);
site.get('/:year/:month/:name', composer);
```

In the `state` object, these would be `state.locals.tag`, `state.locals.year`, `state.locals.month`, etc
- You can use them in a component's `server.js` to do neat things
- You can use them in a component's `template` file to do more neat things ("Welcome to the `:tag` Page!", for example)
