### PR TITLE
path.resolve crashes when run greedily

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -76,7 +76,8 @@ function getComponents() {
 }
 
 /**
- * get a component name, so we can look it up in the file system
+ * Get a component name, so we can look it up in the file system.
+ *
  * @param {string} name
  * @returns {string|false}
  */
@@ -87,44 +88,44 @@ function getComponentName(name) {
 }
 
 /**
- * get the full name of a possibly-scoped npm component
+ * Get the full name of a possibly-scoped npm component
+ *
  * @param {string} name, e.g. 'byline-editor'
  * @returns {string|undefined} e.g. '@nymdev/byline-editor'
  */
-function getNPMName(name) {
+function getScopedModuleName(name) {
   return _.findKey(pkg.dependencies, function (version, dep) {
     return _.contains(dep, name);
   });
 }
 
 /**
- * get path to component folder
+ * Get path to component folder.
+ *
  * @param  {string} name
  * @return {string}
  */
 function getComponentPath(name) {
-  var internalComponentPath, npmName, npmComponentPath;
+  var result = null,
+    modulePath, npmName;
 
   // make sure it's a component we have (either in /components or package.json)
-  if (!getComponentName(name)) {
-    /**
-     * Cannot memoize an exception.
-     *
-     * Also, this isn't a programmer error, unless we're expecting them to check for existence some other way first, so
-     * we should not throw an exception.
-     */
-    return null;
-  } else {
-    internalComponentPath = path.resolve('components', name);
-    npmName = getNPMName(name);
-    npmComponentPath = npmName && path.resolve('node_modules', npmName);
+  if (getComponentName(name)) {
+    modulePath = path.resolve('components', name);
 
-    if (fs.existsSync(internalComponentPath)) {
-      return internalComponentPath;
-    } else if (fs.existsSync(npmComponentPath)) {
-      return npmComponentPath;
+    if (fs.existsSync(modulePath)) {
+      result = modulePath;
+    } else {
+      npmName = getScopedModuleName(name);
+      modulePath = npmName && path.resolve('node_modules', npmName);
+
+      if (fs.existsSync(modulePath)) {
+        result = modulePath;
+      }
     }
   }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
I thought it would be good to run `path.resolve` on both possible internal and possible npm components, but it'll fail if anything before than returns undefined. Doing them non-greedy isn't too much slower, so let's do that.
