### PR TITLE
Add query params to locals.

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -91,7 +91,6 @@ function applyOptions(options, res) {
 
     // options are done at this point; now mix with the data and bind into a self-referencing chain of globals
     state = {
-      _ref: locals._ref,
       site: site,
       locals: locals,
       getTemplate: components.getTemplate

--- a/lib/composer.test.js
+++ b/lib/composer.test.js
@@ -122,22 +122,21 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('sets query params to site, _ref, and locals', function () {
+    it('sets site query param', function () {
       var res = getMockRes(),
-        mockQuery = {site: 'x', _ref: 'y'};
+        mockSiteName = 'x',
+        mockQuery = {site: mockSiteName};
 
       res.req.query = mockQuery; // Adding query params.
       components.getTemplate.returns('some/path');
-      components.get.returns(bluebird.resolve({site: 'x'}));
+      components.get.returns(bluebird.resolve({site: mockSiteName}));
 
       return fn('/components/whatever', res).then(function () {
         var plexArg = plex.render.getCall(0).args[1],
           componentsArg = components.get.getCall(0).args[1];
 
-        expect(componentsArg.site).to.equal('x'); // site query param applied to locals
-        expect(plexArg.site).to.equal('x'); // site query param exposed to templates
-        expect(plexArg._ref).to.equal('y'); // _ref query param exposed to templates
-        expect(plexArg.locals).to.include.keys('site', '_ref'); // all query params in locals
+        expect(componentsArg.site).to.equal(mockSiteName); // site query param to site
+        expect(plexArg.locals.site).to.equal(mockSiteName); // site query params in locals
       });
     });
   });
@@ -364,7 +363,6 @@ describe(_.startCase(filename), function () {
       done();
     });
   });
-
 
   it('gets page without query string', function (done) {
     var res = getMockRes(function () { done('should throw'); }),


### PR DESCRIPTION
Fixes #118 

Also allows `_ref` query param to set `state._ref` which can be useful for getting html of a component instance, since only the template knows where to place the _ref in the html. Did I go too far?
