### PR TITLE
use path instead of url

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -365,7 +365,7 @@ function renderExpressRoute(req, res, next) {
   }
 
   prefix = getExpressRoutePrefix(site) + '/uris/';
-  pageReference = prefix + new Buffer(req.host + req.baseUrl + req.path).toString('base64');
+  pageReference = prefix + new Buffer(req.hostname + req.baseUrl + req.path).toString('base64');
 
   renderUri(pageReference, res)
     .then(function (html) {

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -289,7 +289,7 @@ describe(_.startCase(filename), function () {
       var req = createMockReq(),
         res = createMockRes();
 
-      req.host = 'base.com';
+      req.hostname = 'base.com';
       req.url = '/a';
 
       expectNoLogging();
@@ -301,7 +301,7 @@ describe(_.startCase(filename), function () {
       var req = createMockReq(),
         res = createMockRes();
 
-      req.host = 'base.com';
+      req.hostname = 'base.com';
       req.url = '/a';
 
       expectResult(res, '["base.com/cc","base.com/ccc"]', done);
@@ -313,7 +313,7 @@ describe(_.startCase(filename), function () {
         res = createMockRes(),
         onlyCFilter = filter({wantStrings: true}, function (str) { return str.indexOf('/c') !== -1; });
 
-      req.host = 'base.com';
+      req.hostname = 'base.com';
       req.url = '/';
 
       expectNoLogging();

--- a/test/fixtures/mocks/req.js
+++ b/test/fixtures/mocks/req.js
@@ -22,19 +22,19 @@ function defineWritable(definition) {
 }
 
 module.exports = function () {
-  var host, url, path, baseUrl, query,
+  var hostname, url, path, baseUrl, query,
     req = {};
   req.baseUrl = '';
-  req.host = 'example.com';
+  req.hostname = 'example.com';
   req.vhost = {hostname: 'example.com'};
   req.query = {};
 
   Object.defineProperty(req, 'uri', defineReadOnly({
-    get: function () { return host + baseUrl + url; }
+    get: function () { return hostname + baseUrl + url; }
   }));
 
   Object.defineProperty(req, 'vhost', defineReadOnly({
-    get: function () { return {hostname: host}; }
+    get: function () { return {hostname: hostname}; }
   }));
 
   Object.defineProperty(req, 'originalUrl', defineReadOnly({
@@ -71,16 +71,16 @@ module.exports = function () {
     set: function (value) { baseUrl = value; }
   }));
 
-  Object.defineProperty(req, 'host', defineWritable({
-    get: function () { return host; },
-    set: function (value) { host = value; }
+  Object.defineProperty(req, 'hostname', defineWritable({
+    get: function () { return hostname; },
+    set: function (value) { hostname = value; }
   }));
 
   // defaults
   req.url = '/someUrl';
   req.path = '/someUrl';
   req.baseUrl = '';
-  req.host = 'example.com';
+  req.hostname = 'example.com';
   req.query = {};
 
   return req;


### PR DESCRIPTION
This fixes uris with query params. `req.url` includes them, whereas `req.path` does not.
