### PR TITLE
vhost

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,7 +9,6 @@
 'use strict';
 var _ = require('lodash'),
   express = require('express'),
-  vhost = require('vhost'),
   siteService = require('./sites'),
   composer = require('./composer'),
   responses = require('./responses'),
@@ -174,6 +173,26 @@ function getDefaultSiteSettings(hostname) {
  */
 function resolveSiteController(router, data) {
   return require(data.dir)(router, composer);
+}
+
+/**
+ * Virtual hosts
+ *
+ * Express depends on vhost, so we don't have to.
+ *
+ * @param {string} hostname
+ * @param {express.Router} router
+ * @returns {Function}
+ * @see https://www.npmjs.com/package/vhost
+ */
+function vhost(hostname, router) {
+  return function (req, res, next) {
+    if (req.hostname === hostname) {
+      router(req, res, next);
+    } else {
+      next();
+    }
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "node-fetch": "^1.2.1",
     "nunjucks-filters": "^1.0",
     "through2-filter": "^1.4",
-    "vhost": "^3.0.0",
     "winston": "^0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
So, funny thing.  

Express depends on [vhost](https://www.npmjs.com/package/vhost) just like us, and express supports `X-Forwarded-*`.

If the app using amphora sets express like:

``` js
app.set('trust proxy', 1);
amphora(app).then(function (router) {
  router.listen(port);
  console.log('App listening on port ' + port);
});
```

then magically we support `X-Forwarded-*` too.  

This is the magic of not building a monolithic app that tries to do everything itself.  :grinning: 
