### PR TITLE
do not generate a new uid for bootstrapped data

### DIFF
--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -60,17 +60,40 @@ function list() {
 }
 
 /**
+* Get the id from the data if an id field is present -useful for Bootstrapped data-
+* otherwise generate a new unique id
+* @param {object} data
+* @returns {string}
+*/
+function getDataId(data) {
+  return data.id ? data.id : uid();
+}
+
+/**
+* Delete the id field of data
+* Id is not needed in the data if it is already part of the uri
+* @param {object} data
+*/
+function deleteDataId(data) {
+  delete data.id;
+}
+
+/**
  * PUT to just :id or @latest writes to both locations and creates a new version.
  * @param {string} uri   Assumes no @version
  * @param {object} data
  * @returns {Promise}
  */
 function putLatest(uri, data) {
+  const id = getDataId(data);
+
+  deleteDataId(data);
   data = JSON.stringify(data);
+
   return [
     { type: 'put', key: uri, value: data },
     { type: 'put', key: uri + '@latest', value: data },
-    { type: 'put', key: uri + '@' + uid(), value: data}
+    { type: 'put', key: uri + '@' + id, value: data}
   ];
 }
 
@@ -81,10 +104,14 @@ function putLatest(uri, data) {
  * @returns {Promise}
  */
 function putPublished(uri, data) {
+  const id = getDataId(data);
+
+  deleteDataId(data);
   data = JSON.stringify(data);
+
   return [
     { type: 'put', key: uri + '@published', value: data },
-    { type: 'put', key: uri + '@' + uid(), value: data}
+    { type: 'put', key: uri + '@' + id, value: data}
   ];
 }
 

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -132,6 +132,10 @@ describe(_.startCase(filename), function () {
     it('puts to published', function () {
       fn('domain.com/path/components/whatever', {});
     });
+
+    it('puts to published with id', function () {
+      fn('domain.com/path/components/whatever', {id: 'randomid'});
+    });
   });
 
 


### PR DESCRIPTION
bootstrapped data will provide their own fixed ids, so multiple restarts won't add more and more same data to the persistent storage
