### PR TITLE
remove-versioning

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   timezone:
     America/New_York
   node:
-    version: iojs-v2.3.1
+    version: iojs-v2.5.0
 dependencies:
   pre:
     - npm install -g istanbul

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -138,22 +138,18 @@ describe(_.startCase(filename), function () {
       expect(results).to.deep.include({
         // instance data of components (prefixes all the way down)
         'test/components/image/instances/0': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
-        'test/components/image/instances/0@latest': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
         'test/components/image/instances/0@published': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
 
         // note the prefix added
         'test/components/image/instances/1': '{"_ref":"test/components/image2"}',
-        'test/components/image/instances/1@latest': '{"_ref":"test/components/image2"}',
         'test/components/image/instances/1@published': '{"_ref":"test/components/image2"}',
 
         // note the prefix NOT added
         'test/components/image/instances/2': '{"_ref":"localhost/components/what"}',
-        'test/components/image/instances/2@latest': '{"_ref":"localhost/components/what"}',
         'test/components/image/instances/2@published': '{"_ref":"localhost/components/what"}',
 
         // base data of components
         'test/components/image2': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
-        'test/components/image2@latest': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
         'test/components/image2@published': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}' });
     });
   });

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -68,9 +68,7 @@ function list() {
 function putLatest(uri, data) {
   data = JSON.stringify(data);
   return [
-    { type: 'put', key: uri, value: data },
-    { type: 'put', key: uri + '@latest', value: data },
-    { type: 'put', key: uri + '@' + uid(), value: data}
+    { type: 'put', key: uri, value: data }
   ];
 }
 
@@ -83,8 +81,7 @@ function putLatest(uri, data) {
 function putPublished(uri, data) {
   data = JSON.stringify(data);
   return [
-    { type: 'put', key: uri + '@published', value: data },
-    { type: 'put', key: uri + '@' + uid(), value: data}
+    { type: 'put', key: uri + '@published', value: data }
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "supertest-as-promised": "^2.0.0"
   },
   "engines": {
-    "iojs": "2.3.1"
+    "node": "^4.0.0"
   },
   "engine-strict": true
 }

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -14,8 +14,6 @@ describe(endpointName, function () {
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      updatesOther = apiAccepts.updatesOther(_.camelCase(filename)),
-      createsNewVersion = apiAccepts.createsNewVersion(_.camelCase(filename)),
       cascades = apiAccepts.cascades(_.camelCase(filename)),
       data = { name: 'Manny', species: 'cat' },
       cascadingTarget = 'localhost.example.com/components/validDeep',
@@ -129,13 +127,6 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
 
       cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      updatesOther(path, path + '@latest', {name: 'valid', id: 'newId'}, data);
-      updatesOther(path + '@latest', path, {name: 'valid', id: 'newId'}, data);
-
-      createsNewVersion(path, {name: 'valid', id: 'newId'}, data);
-      createsNewVersion(path + '@latest', {name: 'valid', id: 'newId'}, data);
-      createsNewVersion(path + '@published', {name: 'valid', id: 'newId'}, data);
     });
 
     describe('/components/:name/instances/:id@:version', function () {
@@ -159,12 +150,6 @@ describe(endpointName, function () {
 
       //published version
       version = 'published';
-      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
-      cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), addVersion(version), cascadingDeepData);
-
-      //latest version
-      version = 'latest';
       acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
       cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), addVersion(version), cascadingDeepData);


### PR DESCRIPTION
Removes Feature
- Versioning

Justification
- This was a feature designed before we really knew the requirements
- YAGNI, and undo functionality won't be needed until much later
- Was creating a huge amount of extra data that was making debugging more difficult
- It's ridiculously easy to add it back later
- Most databases that we're targeting have built-in functionality that can do versioning better than we can, so we shouldn't build something ourselves that already exists.
