### PR TITLE
cors

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -7,12 +7,19 @@
  */
 
 'use strict';
-var _ = require('lodash'),
+const _ = require('lodash'),
   express = require('express'),
   siteService = require('./sites'),
   composer = require('./composer'),
   responses = require('./responses'),
-  files = require('./files');
+  files = require('./files'),
+  cors = {
+    origins: '*',
+    methods: ['GET', 'POST', 'PUT', 'DELETE'].join(','),
+    headers: ['Accept', 'Accept-Encoding', 'Authorization', 'Content-Type', 'Host', 'Referer', 'Origin', 'User-Agent',
+      'X-Forwarded-For', 'X-Forwarded-Host', 'X-Forwarded-Proto'].join(',')
+  };
+
 
 /**
  * Get site from options, verify its real, throw if not.
@@ -101,6 +108,30 @@ function addControllerRoutes(router) {
 }
 
 /**
+ * Add CORS
+ *
+ * Overwritten by site settings
+ * @param {object} site
+ * @returns {Function}
+ */
+function addCORS(site) {
+  const local = site.cors || {};
+
+  return function (req, res, next) {
+    if (req.headers.origin) {
+      res.header('Access-Control-Allow-Origin', local.origins || cors.origins);
+    }
+    if (req.method === 'OPTIONS') {
+      res.header('Access-Control-Allow-Methods', local.methods || cors.methods);
+      res.header('Access-Control-Allow-Headers', local.headers || cors.headers);
+      res.status(200).send();
+    } else {
+      next();
+    }
+  };
+}
+
+/**
  *
  * @param {express.Router} router
  * @param {object} options
@@ -113,10 +144,10 @@ function addSite(router, options) {
     site = getSite(options),
     siteRouter = express.Router();
 
-  // add res.locals.site (slug) to every request
   siteRouter.use(addUri);
   siteRouter.use(addSiteLocals(site));
   siteRouter.use(addAssetDirectory(site));
+  siteRouter.use(addCORS(site));
 
   // components, pages and schema have priority over user-defined routes
   addControllerRoutes(siteRouter);


### PR DESCRIPTION
New Feature
- CORS support where the default is:

```
Access-Control-Allow-Headers:Accept,Accept-Encoding,Authorization,Content-Type,Host,Referer,Origin,User-Agent,X-Forwarded-For,X-Forwarded-Host,X-Forwarded-Proto
Access-Control-Allow-Methods:GET,POST,PUT,DELETE
Access-Control-Allow-Origin:*
```
- CORS can be overwritten on a per-site basis by setting the config, and each is optional:

```
name: New York Media Press Room
host: nymag.com
path: /press
assetDir: public
assetPath: /press
twitter: nymagpr
cors:
  origins: http://qa.nymag.com
  headers: Authorization,Content-Type
  methods: GET
```
