### PR TITLE
block-uri-to-itself

### DIFF
--- a/lib/routes/uris.js
+++ b/lib/routes/uris.js
@@ -25,6 +25,10 @@ function getUriFromReference(req, res) {
  */
 function putUriFromReference(req, res) {
   responses.expectText(function () {
+    if (req.uri === req.body) {
+      throw new Error('Client: Cannot point uri at itself');
+    }
+
     return db.put(req.uri, req.body).return(req.body);
   }, res);
 }

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -49,6 +49,9 @@ describe(endpointName, function () {
 
       acceptsTextBody(path, {name: 'valid'}, data, 200, data);
       acceptsTextBody(path, {name: 'missing'}, data, 200, data);
+
+      // deny uris pointing to themselves
+      acceptsTextBody(path, {name: 'valid'}, 'localhost.example.com/uris/valid', 400);
     });
   });
 });


### PR DESCRIPTION
Patch
- Should 400 if `PUT`ting uri that points to itself
