### PR TITLE
block-ref-at-root

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -183,6 +183,20 @@ function notAcceptable(options) {
 }
 
 /**
+ * This route not allowed
+ * @returns {function}
+ */
+function denyReferenceAtRoot(req, res, next) {
+  const body = req.body;
+
+  if (_.has(body, '_ref')) {
+    sendDefaultResponseForCode(400, 'Reference (_ref) at root of object is not acceptable', res);
+  } else {
+    next();
+  }
+}
+
+/**
  * @param {{varyBy: [string]}} options
  * @returns {function}
  */
@@ -450,6 +464,7 @@ module.exports.serverError = serverError; // bad 500
 // generic handlers
 module.exports.varyWithoutExtension = varyWithoutExtension; // adds Vary header when missing extension
 module.exports.onlyCachePublished = onlyCachePublished; // adds cache control when published or not
+module.exports.denyReferenceAtRoot = denyReferenceAtRoot; // nice 400 about _ref at root of object
 module.exports.handleError = handleError; // 404 or 500 based on exception
 module.exports.acceptJSONOnly = acceptJSONOnly; // 406 on non-JSON body
 module.exports.onlyAcceptExtensions = onlyAcceptExtensions; // nice 404 for unsupported extensions

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -152,17 +152,20 @@ function routes(router) {
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.all('/:name@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.get('/:name@:version', route.get);
+  router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@:version', route.put);
 
   router.all('/:name', responses.acceptJSONOnly);
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.get('/:name', route.get);
+  router.put('/:name', responses.denyReferenceAtRoot);
   router.put('/:name', route.put);
   router.delete('/:name', route.del);
 
   router.all('/:name/instances', responses.acceptJSONOnly);
   router.all('/:name/instances', responses.methodNotAllowed({allow: ['get', 'post']}));
   router.get('/:name/instances', responses.listWithoutVersions());
+  router.post('/:name/instances', responses.denyReferenceAtRoot);
   router.post('/:name/instances', route.post);
   router.get('/:name/instances/:id.:ext', responses.onlyAcceptExtensions({extensions: acceptedExtensions}));
   router.get('/:name/instances/:id.:ext', route.extension);
@@ -170,11 +173,13 @@ function routes(router) {
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
   router.all('/:name/instances/:id@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.get('/:name/instances/:id@:version', route.get);
+  router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id@:version', route.put);
 
   router.all('/:name/instances/:id', responses.acceptJSONOnly);
   router.all('/:name/instances/:id', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.get('/:name/instances/:id', route.get);
+  router.put('/:name/instances/:id', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id', route.put);
   router.delete('/:name/instances/:id', route.del);
 

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -85,6 +85,7 @@ function routes(router) {
   router.all('/', responses.methodNotAllowed({allow: ['get', 'post']}));
   router.all('/', responses.notAcceptable({accept: ['application/json']}));
   router.get('/', responses.listWithoutVersions());
+  router.post('/', responses.denyReferenceAtRoot);
   router.post('/', route.post);
 
   router.all('/:name.:ext', responses.methodNotAllowed({allow: ['get']}));
@@ -94,12 +95,14 @@ function routes(router) {
   router.all('/:name@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.get('/:name@:version', responses.getRouteFromDB);
+  router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@published', route.putPublish);
   router.put('/:name@:version', responses.putRouteFromDB);
 
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.all('/:name', responses.notAcceptable({accept: ['application/json']}));
   router.get('/:name', responses.getRouteFromDB);
+  router.put('/:name', responses.denyReferenceAtRoot);
   router.put('/:name', responses.putRouteFromDB);
 }
 

--- a/test/api/components/post.js
+++ b/test/api/components/post.js
@@ -69,6 +69,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/components/:name/instances/:id', function () {

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -60,6 +60,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing'}, 406);
 
       cascades(path, {name: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/components/:name/schema', function () {
@@ -92,6 +95,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing', version: version}, 406);
 
       cascades(path, {name: 'valid', version: version}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', version: version}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/components/:name/instances', function () {
@@ -127,6 +133,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
 
       cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/components/:name/instances/:id@:version', function () {
@@ -153,6 +162,9 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
       cascades(path, {name: 'valid', version: version, id: 'valid'}, cascadingData(version), addVersion(version), cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', version: version, id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
   });
 });

--- a/test/api/pages/post.js
+++ b/test/api/pages/post.js
@@ -45,6 +45,9 @@ describe(endpointName, function () {
         expect(body._ref).to.match(/^localhost.example.com\/pages\/.+/);
       });
       acceptsHtml(path, {}, 406, '406 text/html not acceptable');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {}, _.assign({_ref: 'whatever'}, pageData), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/pages/:name', function () {

--- a/test/api/pages/put.js
+++ b/test/api/pages/put.js
@@ -75,6 +75,9 @@ describe(endpointName, function () {
 
       acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, pageData), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/pages/:name@:version', function () {
@@ -97,6 +100,9 @@ describe(endpointName, function () {
       cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingPageData.center, version), versionedDeepData(version));
       cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingPageData.layout, version), versionedDeepData(version));
       cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingTarget, version), componentData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', version: version}, _.assign({_ref: 'whatever'}, pageData), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
   });
 });


### PR DESCRIPTION
Patch:
- Block `_ref` at root of objects on PUT and POST for pages and components, returning 400

Matching changing for https://github.com/nymag/clay-kiln/pull/242
