### PR TITLE
stop-double-bootstrap

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -186,14 +186,12 @@ function load(data, prefix) {
   });
   promiseComponentsOps = saveWithInstances(prefix + '/components/', data.components, function (name, item) {
     return bluebird.join(
-      components.getPutOperations(name, _.cloneDeep(item)),
-      components.getPutOperations(name + '@published', _.cloneDeep(item))
+      components.getPutOperations(name, _.cloneDeep(item))
     ).then(_.flatten);
   });
   promisePagesOps = saveObjects(prefix + '/pages/', data.pages, function (name, item) {
     return [
-      getPutOperation(name, item),
-      getPutOperation(name + '@published', item)
+      getPutOperation(name, item)
     ];
   });
 

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -156,8 +156,7 @@ describe(_.startCase(filename), function () {
         return pipeToPromise(db.list({prefix: 'test/pages', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.equal({
-          'test/pages/0': '{"layout":"test/a/b","head":"test/c/d"}',
-          'test/pages/0@published': '{"layout":"test/a/b","head":"test/c/d"}'
+          'test/pages/0': '{"layout":"test/a/b","head":"test/c/d"}'
         });
       });
     });
@@ -173,19 +172,16 @@ describe(_.startCase(filename), function () {
         expect(results).to.deep.include({
           // instance data of components (prefixes all the way down)
           'test/components/image/instances/0': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
-          'test/components/image/instances/0@published': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
 
           // note the prefix added
           'test/components/image/instances/1': '{"_ref":"test/components/image2"}',
-          'test/components/image/instances/1@published': '{"_ref":"test/components/image2"}',
 
           // note the prefix NOT added
           'test/components/image/instances/2': '{"_ref":"localhost/components/what"}',
-          'test/components/image/instances/2@published': '{"_ref":"localhost/components/what"}',
 
           // base data of components
-          'test/components/image2': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
-          'test/components/image2@published': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}' });
+          'test/components/image2': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}'
+        });
       });
     });
   });

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -11,7 +11,7 @@ For a broader and less specific overview of routing, please see the [project's r
 - [Pages](#pages)
 - [URIs](#uris)
 - [Lists](#lists)
-- [Versions](#Versions)
+- [Versions](#versions)
 - [RESTful API](#restful-api)
 - [Errors](#errors)
 
@@ -132,6 +132,8 @@ A URI is used to redirect some slug or URI to another page or component.  They c
 
 - `example.com` is `/uris/ZXhhbXBsZS5jb20=` => `/pages/jdskla@published`
 - `example.com/other/` is `/uris/ZXhhbXBsZS5jb20vb3RoZXI=` => `/pages/4revd3s@published`
+
+A URI is assumed to be pointing at the `@published` version if another version is not provided.  Therefore, only published content or specially tagged versions can be publicly exposed through URIs.
 
 ## Lists
 

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -41,7 +41,7 @@ function replaceAllVersions(version) {
  */
 function isPropagatingVersion(uri) {
   var version = uri.split('@')[1];
-  
+
   return !!version && _.contains(propagatingVersions, version);
 }
 

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -7,6 +7,10 @@ function setPropagatingVersions(value) {
   propagatingVersions = value;
 }
 
+function getPropagatingVersions() {
+  return propagatingVersions;
+}
+
 function replaceVersion(uri, version) {
   if (version) {
     uri = uri.split('@')[0] + '@' + version;
@@ -37,7 +41,8 @@ function replaceAllVersions(version) {
  */
 function isPropagatingVersion(uri) {
   var version = uri.split('@')[1];
-  return version && _.contains(propagatingVersions, version);
+  
+  return !!version && _.contains(propagatingVersions, version);
 }
 
 
@@ -45,4 +50,5 @@ function isPropagatingVersion(uri) {
 module.exports.replaceVersion = replaceVersion;
 module.exports.replaceAllVersions = replaceAllVersions;
 module.exports.setPropagatingVersions = setPropagatingVersions;
+module.exports.getPropagatingVersions = getPropagatingVersions;
 module.exports.isPropagatingVersion = isPropagatingVersion;

--- a/lib/services/references.test.js
+++ b/lib/services/references.test.js
@@ -46,7 +46,16 @@ describe(_.startCase(filename), function () {
   });
 
   describe('setPropagatingVersions', function () {
-    var fn = lib[this.title];
+    var fn = lib[this.title],
+      originalValue;
+
+    before(function () {
+      originalValue = lib.getPropagatingVersions();
+    });
+
+    after(function () {
+      lib.setPropagatingVersions(originalValue);
+    });
 
     it('sets', function () {
       expect(function () { fn([]); }).to.not.throw();

--- a/lib/services/uris.js
+++ b/lib/services/uris.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const db = require('./db');
+const db = require('./db'),
+  references = require('./references');
 
 /**
  * @param {string} uri
@@ -18,6 +19,10 @@ function get(uri) {
 function put(uri, body) {
   if (uri === body) {
     throw new Error('Client: Cannot point uri at itself');
+  }
+
+  if (references.isPropagatingVersion(body)) {
+    throw new Error('Client: Cannot point uri at propagating version, such as @published');
   }
 
   return db.put(uri, body).return(body);

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -49,6 +49,8 @@ describe(endpointName, function () {
 
       acceptsTextBody(path, {name: 'valid'}, data, 200, data);
       acceptsTextBody(path, {name: 'missing'}, data, 200, data);
+      // propagating versions shouldn't be here. Only published things can be public, so all uris are assumed to be @published already
+      acceptsTextBody(path, {name: 'valid'}, 'domain/pages/test@published', 400, 'Bad Request');
 
       // deny uris pointing to themselves
       acceptsTextBody(path, {name: 'valid'}, 'localhost.example.com/uris/valid', 400);


### PR DESCRIPTION
Patch:
- Stop pushing to @published for all things in bootstrap
- Block writing @published or @latest to `/uris`.  All things in uris are assumed to be @published ("public") anyway, unless given a different version.