### PR TITLE
Schedule

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,6 @@
 module.exports = require('./lib/setup');
 module.exports.db = require('./lib/services/db');
 module.exports.components = require('./lib/services/components');
+module.exports.schedule = require('./lib/services/schedule');
 module.exports.pages = require('./lib/services/pages');
 module.exports.sites = require('./lib/services/sites');

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -16,21 +16,6 @@ describe(_.startCase(filename), function () {
   var sandbox,
     bootstrapFake;
 
-  /**
-   * @param {Stream} pipe
-   * @returns {Promise}
-   */
-  function pipeToPromise(pipe) {
-    var str = '',
-      d = bluebird.defer();
-    pipe.on('data', function (data) { str += data; })
-      .on('error', d.reject)
-      .on('end', function () {
-        d.resolve(str);
-      });
-    return d.promise;
-  }
-
   before(function () {
     this.timeout(400);
     bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap'));
@@ -136,7 +121,7 @@ describe(_.startCase(filename), function () {
       this.timeout(400);
 
       return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return pipeToPromise(db.list({prefix: 'test/uris', limit: -1}));
+        return db.pipeToPromise(db.list({prefix: 'test/uris', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.equal({
           'test/uris/YQ==': 'b',
@@ -153,7 +138,7 @@ describe(_.startCase(filename), function () {
       this.timeout(400);
 
       return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return pipeToPromise(db.list({prefix: 'test/pages', limit: -1}));
+        return db.pipeToPromise(db.list({prefix: 'test/pages', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.equal({
           'test/pages/0': '{"layout":"test/a/b","head":"test/c/d"}'
@@ -167,7 +152,7 @@ describe(_.startCase(filename), function () {
       this.timeout(400);
 
       return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return pipeToPromise(db.list({prefix: 'test/components', limit: -1}));
+        return db.pipeToPromise(db.list({prefix: 'test/components', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.include({
           // instance data of components (prefixes all the way down)

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -3,7 +3,6 @@
 var _ = require('lodash'),
   files = require('./files'),
   path = require('path'),
-  bluebird = require('bluebird'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./bootstrap'),
   db = require('./services/db'),

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -389,7 +389,7 @@ function expectHTML(fn, res) {
  * List all things in the db
  * @param {object} [options]
  * @param {string} [options.prefix]
- * @param {string} [options.values]
+ * @param {boolean} [options.values]
  * @param {function|array} [options.transforms]
  * @returns {function}
  */

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -11,6 +11,7 @@ For a broader and less specific overview of routing, please see the [project's r
 - [Pages](#pages)
 - [URIs](#uris)
 - [Lists](#lists)
+- [Schedule](#schedule)
 - [Versions](#versions)
 - [RESTful API](#restful-api)
 - [Errors](#errors)
@@ -142,13 +143,55 @@ A URI is assumed to be pointing at the `@published` version if another version i
 /lists/:id
 ```
 
-Lists are a _temporary_ solution until search functionality is discussed.  It is currently used for the tags component and the autocomplete behaviour as a temporary place to store lists of information.  It can store any list of data on a `PUT`, and return back the same list of data with a `GET`.
+Lists are a _temporary_ solution until search functionality is discussed.  It is currently used for the tags component and the autocomplete behavior as a temporary place to store lists of information.  It can store any list of data on a `PUT`, and return back the same list of data with a `GET`.
+
+## Schedule
+
+```
+/schedule
+/schedule/:id
+```
+
+Schedule is a list of pages or components that will be published in the future.
+
+### List of scheduled items
+
+`GET /schedule` will return a list of scheduled items, such as:
+```json
+[
+  {
+    "key": "domain.com/some-path/schedule/3f-abc",
+    "value": "'at':44392893402093,'publish':'abc'"
+  }
+]
+```
+
+### Add a scheduled item
+
+`POST /schedule` will add an item to be published in the future. The format of the item should be of `{ at: <timestamp>, publish: "<hostname/pages/some-page>" }`, where the `at` is a UNIX timestamp and the `publish` is a ref to a page or component.  On success, it will return a 201 with
+```json
+{
+  "_ref": "<site hostname and path>/schedule/<some-id>",
+  "at": 44392893402093,
+  "publish": "<hostname/pages/some-page>"
+}
+```
+
+### Remove a scheduled item
+
+`DELETE /schedule/:some-id` will remove the scheduling of a publish in the future.  On success, it will return a 200 with
+```json
+{
+  "at": 44392893402093,
+  "publish": "<site hostname and path>/pages/some-page>"
+}
+```
 
 ## Versions
 
 ### Propagating Versions
 
-Some versions have a special behaviour called _propagating_, which any reference within their data is changed to be the same version as itself.
+Some versions have a special behavior called _propagating_, which any reference within their data is changed to be the same version as itself.
 
 The current propagating versions are:
 * published

--- a/lib/routes/schedule.js
+++ b/lib/routes/schedule.js
@@ -1,0 +1,52 @@
+/**
+ * Controller for Pages
+ *
+ * @module
+ */
+
+'use strict';
+
+var _ = require('lodash'),
+  responses = require('../responses'),
+  controller = require('../services/schedule');
+
+/**
+ * All routes go here.
+ *
+ * They will all have the form (req, res), but never with next()
+ *
+ * @namespace
+ */
+let route = _.bindAll({
+  /**
+   * @param req
+   * @param res
+   */
+  post: function (req, res) {
+    responses.expectJSON(function () {
+      return controller.create(req.uri, req.body)
+        .then(function (result) {
+          // creation success!
+          res.status(201);
+          return result;
+        });
+    }, res);
+  }
+});
+
+function routes(router) {
+  router.use(responses.varyWithoutExtension({varyBy: ['Accept']}));
+  router.use(responses.onlyCachePublished);
+
+  router.all('/', responses.methodNotAllowed({allow: ['get', 'post']}));
+  router.all('/', responses.notAcceptable({accept: ['application/json']}));
+  router.get('/', responses.list({keys: true, values: true, isArray: true}));
+  router.post('/', route.post);
+
+  router.all('/:name', responses.methodNotAllowed({allow: ['get', 'delete']}));
+  router.all('/:name', responses.notAcceptable({accept: ['application/json']}));
+  router.get('/:name', responses.getRouteFromDB);
+  router.delete('/:name', responses.deleteRouteFromDB);
+}
+
+module.exports = routes;

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -16,7 +16,7 @@ var _ = require('lodash'),
 
 /**
  * Use ES6 promises
- * @returns {{}}
+ * @returns {{apply: function}}
  */
 function defer() {
   var def = bluebird.defer();
@@ -33,35 +33,51 @@ function defer() {
 }
 
 /**
+ * Convert a pipe (stream) to a promise
+ *
+ * @param {Stream} pipe
+ * @returns {Promise}
+ */
+function pipeToPromise(pipe) {
+  var str = '',
+    d = defer();
+
+  pipe.on('data', function (data) { str += data; })
+    .on('error', d.reject)
+    .on('end', function () { d.resolve(str); });
+  return d.promise;
+}
+
+/**
  * @param {string} key
  * @param {string} value
  * @returns {Promise}
  */
-module.exports.put = function (key, value) {
+function put(key, value) {
   var deferred = defer();
   db.put(key, value, deferred.apply);
   return deferred.promise;
-};
+}
 
 /**
  * @param {string} key
  * @returns {Promise}
  */
-module.exports.get = function (key) {
+function get(key) {
   var deferred = defer();
   db.get(key, deferred.apply);
   return deferred.promise;
-};
+}
 
 /**
  * @param {string} key
  * @returns {Promise}
  */
-module.exports.del = function (key) {
+function del(key) {
   var deferred = defer();
   db.del(key, deferred.apply);
   return deferred.promise;
-};
+}
 
 /**
  * Get a read stream of all the keys.
@@ -76,7 +92,7 @@ module.exports.del = function (key) {
  * @param {object} [options]  Defaults to limit of 10.
  * @returns {ReadStream}
  */
-module.exports.list = function (options) {
+function list(options) {
   options = _.defaults(options || {}, {
     limit: 10,
     keys: true,
@@ -116,23 +132,23 @@ module.exports.list = function (options) {
   }
 
   return readStream.pipe(jsonTransform(transformOptions));
-};
+}
 
 /**
  * @param {Array} ops
  * @param {object} [options]
  * @returns {Promise}
  */
-module.exports.batch = function (ops, options) {
+function batch(ops, options) {
   var deferred = defer();
   db.batch(ops, options || {}, deferred.apply);
   return deferred.promise;
-};
+}
 
 /**
  * Clear all records from the DB.  (useful for unit testing)
  */
-module.exports.clear = function () {
+function clear() {
   var errors = [],
     ops = [],
     deferred = defer();
@@ -154,7 +170,7 @@ module.exports.clear = function () {
   });
 
   return deferred.promise;
-};
+}
 
 /**
  * Format a series of batch operations in a consistent way.
@@ -163,7 +179,7 @@ module.exports.clear = function () {
  * @param {[{type: string, key: string, value: string}]} ops
  * @returns {string}
  */
-module.exports.formatBatchOperations = function (ops) {
+function formatBatchOperations(ops) {
   return _.map(ops, function (op) {
     var str,
       value = op.value;
@@ -181,16 +197,18 @@ module.exports.formatBatchOperations = function (ops) {
 
     return str;
   }).join('\n');
-};
+}
 
-module.exports.getDB = function () {
-  return db;
-};
-
-module.exports.setDB = function (value) {
-  db = value;
-};
-
+module.exports.get = get;
+module.exports.put = put;
+module.exports.del = del;
+module.exports.list = list;
+module.exports.batch = batch;
+module.exports.clear = clear;
+module.exports.formatBatchOperations = formatBatchOperations;
+module.exports.getDB = function () { return db; };
+module.exports.setDB = function (value) { db = value; };
+module.exports.pipeToPromise = pipeToPromise;
 Eventify.enable(module.exports);
 
 // when any put, batch or del is made, expose it to the outside only if it is a success; also: never block for them

--- a/lib/services/db.test.js
+++ b/lib/services/db.test.js
@@ -109,21 +109,10 @@ describe(_.startCase(filename), function () {
   describe('list', function () {
     var fn = lib[this.title];
 
-    function pipeToPromise(pipe) {
-      var str = '',
-        d = bluebird.defer();
-      pipe.on('data', function (data) { str += data; })
-        .on('error', d.reject)
-        .on('end', function () {
-          d.resolve(str);
-        });
-      return d.promise;
-    }
-
     it('default behaviour', function () {
       return bluebird.join(lib.put('1', '2'), lib.put('3', '4'), lib.put('5', '6'))
         .then(function () {
-          return pipeToPromise(fn());
+          return lib.pipeToPromise(fn());
         }).then(function (str) {
           expect(str).to.equal('{"1":"2","3":"4","5":"6"}');
         });
@@ -132,7 +121,7 @@ describe(_.startCase(filename), function () {
     it('can get keys-only in array structure', function () {
       return bluebird.join(lib.put('1', '2'), lib.put('3', '4'), lib.put('5', '6'))
         .then(function () {
-          return pipeToPromise(fn({keys: true, values: false}));
+          return lib.pipeToPromise(fn({keys: true, values: false}));
         }).then(function (str) {
           expect(str).to.equal('["1","3","5"]');
         });
@@ -141,7 +130,7 @@ describe(_.startCase(filename), function () {
     it('can get values-only in array structure', function () {
       return bluebird.join(lib.put('1', '2'), lib.put('3', '4'), lib.put('5', '6'))
         .then(function () {
-          return pipeToPromise(fn({keys: false, values: true}));
+          return lib.pipeToPromise(fn({keys: false, values: true}));
         }).then(function (str) {
           expect(str).to.equal('["2","4","6"]');
         });
@@ -150,20 +139,20 @@ describe(_.startCase(filename), function () {
     it('can get key-value in object structure in array', function () {
       return bluebird.join(lib.put('1', '2'), lib.put('3', '4'), lib.put('5', '6'))
         .then(function () {
-          return pipeToPromise(fn({isArray: true}));
+          return lib.pipeToPromise(fn({isArray: true}));
         }).then(function (str) {
           expect(str).to.equal('[{"key":"1","value":"2"},{"key":"3","value":"4"},{"key":"5","value":"6"}]');
         });
     });
 
     it('can return empty data safely for arrays', function () {
-      return pipeToPromise(fn({isArray: true})).then(function (str) {
+      return lib.pipeToPromise(fn({isArray: true})).then(function (str) {
         expect(str).to.equal('[]');
       });
     });
 
     it('can return empty data safely for objects', function () {
-      return pipeToPromise(fn({isArray: false})).then(function (str) {
+      return lib.pipeToPromise(fn({isArray: false})).then(function (str) {
         expect(str).to.equal('{}');
       });
     });

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -139,8 +139,7 @@ function getRecursivePublishedPutOperations(locals) {
       .then(function (data) {
         return components.getPutOperations(references.replaceVersion(rootComponentRef, published), data, locals);
       });
-  }
-
+  };
 }
 
 /**

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -19,6 +19,8 @@ function addOp(uri, data, ops) {
     key: uri,
     value: JSON.stringify(data)
   });
+
+  return ops;
 }
 
 /**
@@ -90,7 +92,7 @@ function applyBatch(ops) {
 
 /**
  * Replace the referenced things in the page data with a different version
- * @param {{}} data
+ * @param {object} data
  * @param {string} version
  * @returns object
  */
@@ -109,38 +111,60 @@ function replacePageReferenceVersions(data, version) {
 }
 
 /**
- * Create new versions of all components and save to them all to @published
- *
+ * Get latest data of uri@latest
  * @param {string} uri
- * @param {object} data
- * @param {object} [locals]
  * @returns {Promise}
  */
-function publish(uri, data, locals) {
-  var published = 'published',
-    pageRefs = _.flatten(_.values(data));
-  uri = references.replaceVersion(uri, published);
-  data = replacePageReferenceVersions(data, published);
+function getLatestData(uri) {
+  return db.get(references.replaceVersion(uri)).then(JSON.parse);
+}
 
-  return bluebird.map(pageRefs, function (pageRef) {
+/**
+ * Get a list of all operations with all references converted to @published
+ * @returns {function}
+ */
+function getRecursivePublishedPutOperations(locals) {
+  return function (rootComponentRef) {
+    const published = 'published';
+
     /**
      * 1) Get reference (could be latest, could be other)
      * 2) Get all references within reference
      * 3) Replace all references with @published (including root reference)
      * 4) Get list of put operations needed
      */
-    return components.get(pageRef, locals)
+    return components.get(rootComponentRef, locals)
       .then(composer.resolveDataReferences)
       .then(references.replaceAllVersions(published))
       .then(function (data) {
-        return components.getPutOperations(references.replaceVersion(pageRef, published), data, locals);
+        return components.getPutOperations(references.replaceVersion(rootComponentRef, published), data, locals);
       });
-  }).then(_.flatten) // only one level of flattening needed, because getPutOperations should have flattened its list already
-    .then(function (ops) {
-      // add page PUT operation last
-      addOp(uri, data, ops);
-      return ops;
-    }).then(applyBatch);
+  }
+
+}
+
+/**
+ * Get latest data of uri@latest
+ * @param {string} uri
+ * @param {object} data
+ * @param {object} [locals]
+ * @returns {Promise}
+ */
+function publish(uri, data, locals) {
+  return bluebird.try(function () {
+    return data || getLatestData(uri);
+  }).then(function (data) {
+    const published = 'published';
+
+    return bluebird.map(_.flatten(_.values(data)), getRecursivePublishedPutOperations(locals))
+      .then(_.flatten) // only one level of flattening needed, because getPutOperations should have flattened its list already
+      .then(function (ops) {
+        // convert the data to all @published
+        data = replacePageReferenceVersions(data, published);
+        // add page PUT operation last
+        return addOp(references.replaceVersion(uri, published), data, ops);
+      });
+  }).then(applyBatch);
 }
 
 /**
@@ -165,9 +189,7 @@ function create(uri, data, locals) {
     return getPageClonePutOperations(pageData).then(function (ops) {
       pageData.layout = layoutReference;
 
-      addOp(pageReference, pageData, ops);
-
-      return ops;
+      return addOp(pageReference, pageData, ops);
     });
   }).then(applyBatch).then(function (newPage) {
     // if successful, return new page object, but include the (optional) self reference to the new page.

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -115,6 +115,16 @@ describe(_.startCase(filename), function () {
         expect(result).to.deep.equal({ layout: 'domain.com/path/components/thing@published' });
       });
     });
+
+    it('publishes', function () {
+      components.get.returns(bluebird.resolve({}));
+      db.get.returns(bluebird.resolve(JSON.stringify({layout: 'domain.com/path/components/thing'})));
+      db.batch.returns(bluebird.resolve());
+
+      return fn('domain.com/path/pages/thing').then(function (result) {
+        expect(result).to.deep.equal({ layout: 'domain.com/path/components/thing@published' });
+      });
+    });
   });
 
   describe('replacePageReferenceVersions', function () {

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -11,6 +11,11 @@ function getPropagatingVersions() {
   return propagatingVersions;
 }
 
+/**
+ * @param {string} uri
+ * @param {string} [version]
+ * @returns {string}
+ */
 function replaceVersion(uri, version) {
   if (version) {
     uri = uri.split('@')[0] + '@' + version;
@@ -24,7 +29,7 @@ function replaceVersion(uri, version) {
 
 /**
  * @param {string} version
- * @returns {Function}
+ * @returns {function}
  */
 function replaceAllVersions(version) {
   return function (data) {

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -3,10 +3,16 @@
 var _ = require('lodash'),
   propagatingVersions = ['published', 'latest'];
 
+/**
+ * @param {[string]} value
+ */
 function setPropagatingVersions(value) {
   propagatingVersions = value;
 }
 
+/**
+ * @returns {[string]}
+ */
 function getPropagatingVersions() {
   return propagatingVersions;
 }

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -13,6 +13,9 @@ const _ = require('lodash'),
   pages = require('../services/pages'),
   log = require('../log');
 
+/**
+ * @param {number} value
+ */
 function setScheduleInterval(value) {
   intervalDelay = value;
 }

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -1,0 +1,102 @@
+'use strict';
+
+var interval;
+const _ = require('lodash'),
+  bluebird = require('bluebird'),
+  db = require('../services/db'),
+  siteService = require('../services/sites'),
+  scheduledAtProperty = 'at',
+  publishProperty = 'publish',
+  pages = require('../services/pages'),
+  log = require('../log'),
+  intervalDelay = 60 * 1000; // one minute
+
+/**
+ * @param {string} uri
+ * @param {number} at
+ * @returns {Promise.<T>}
+ */
+function publishPage(uri, at) {
+  return pages.publish(uri)
+    .then(function () {
+      log.info('published', uri, 'at', at);
+    }).catch(function (err) {
+      log.error('error publishing', uri, 'at', at, err.stack);
+    });
+}
+
+/**
+ * @param {[{at: number, publish: string}]} list
+ * @returns {Promise}
+ */
+function publishByTime(list) {
+  const promises = [],
+    now = new Date().getTime();
+
+  // list is assumed to be in order of when they should run
+  while (list.length && list[0][scheduledAtProperty] < now) {
+    let item = list.shift(),
+      at = item[scheduledAtProperty],
+      publish = item[publishProperty];
+
+    if (publish.indexOf('/pages/')) {
+      promises.push(publishPage(publish, at));
+    }
+  }
+
+  return bluebird.all(promises);
+}
+
+/**
+ * Start waiting for things to publish (but only if we're not already listening)
+ */
+function startListening() {
+  if (!interval) {
+    interval = setInterval(function () {
+      // get list for each site
+      return _.map(siteService.sites(), function (site) {
+        return db.pipeToPromise(db.list({prefix: site.host + site.path + '/schedule'})).then(publishByTime);
+      });
+    }, intervalDelay);
+  }
+}
+
+/**
+ * Stop waiting for things to publish
+ */
+function stopListening() {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+  }
+}
+
+/**
+ * Create a schedule item to publish something in the future
+ * @param {string} uri
+ * @param {object} data
+ * @returns {Promise}
+ */
+function create(uri, data) {
+  var reference;
+  const prefix = uri.substr(0, uri.indexOf('/schedule')),
+    at = data[scheduledAtProperty],
+    publish = data[publishProperty];
+
+  if (!_.isNumber(at)) {
+    throw new Error('Client: Missing "at" property as number.');
+  } else if (!_.isString(publish)) {
+    throw new Error('Client: Missing "publish" property as string.');
+  }
+
+  reference = prefix + '/schedule/' + at.toString(36) + '-' +
+    publish.replace(/[\/\.]/g, '-').replace(/-(?=-)/g, '');
+
+  return db.put(reference, data).then(function () {
+    return _.assign({_ref: reference}, data);
+  });
+}
+
+module.exports.create = create;
+module.exports.startListening = startListening;
+module.exports.stopListening = stopListening;

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -1,28 +1,92 @@
 'use strict';
 
-var interval;
+var interval,
+  intervalDelay = 60000; // one minute
 const _ = require('lodash'),
   bluebird = require('bluebird'),
+  components = require('../services/components'),
   db = require('../services/db'),
+  references = require('../services/references'),
   siteService = require('../services/sites'),
   scheduledAtProperty = 'at',
   publishProperty = 'publish',
   pages = require('../services/pages'),
-  log = require('../log'),
-  intervalDelay = 60 * 1000; // one minute
+  log = require('../log');
+
+function setScheduleInterval(value) {
+  intervalDelay = value;
+}
 
 /**
  * @param {string} uri
- * @param {number} at
- * @returns {Promise.<T>}
+ * @returns {Promise}
  */
-function publishPage(uri, at) {
-  return pages.publish(uri)
-    .then(function () {
-      log.info('published', uri, 'at', at);
+function publishPage(uri) {
+  return pages.publish(uri);
+}
+
+/**
+ * @param {string} uri
+ * @returns {Promise}
+ */
+function publishComponent(uri) {
+  return components.get(references.replaceVersion(uri)).then(function (data) {
+    return components.put(references.replaceVersion(uri, 'published'), data);
+  });
+}
+
+/**
+ * Get all the publishable things in the schedule
+ * @param {[{key: string, value: string}]} list
+ * @param {number} now
+ * @returns {[{key: string, value: {at: number, publish: string}}]}
+ */
+function getPublishable(list, now) {
+  // attempt to convert JSON to Object
+  list = _.compact(_.map(list, function (item) {
+    try {
+      item.value = item.value && JSON.parse(item.value);
+      return item;
+    } catch (ex) {
+      log.error('Cannot parse JSON of ' + item.value);
+    }
+  }));
+
+  return _.select(list, function (item) {
+    return item.value && item.value[scheduledAtProperty] < now;
+  });
+}
+
+/**
+ * @param {string} uri
+ * @returns {Promise}
+ */
+function publish(uri) {
+  var promise;
+
+  if (uri) {
+    if (uri.indexOf('/pages/') > -1) {
+      promise = publishPage(uri);
+    } else if (uri.indexOf('/components/') > -1) {
+      promise = publishComponent(uri);
+    } else {
+      log.error('Unknown publish type: ' + uri);
+    }
+  } else {
+    log.error('Missing publish type');
+  }
+
+  if (promise) {
+    promise.then(function () {
+      log.info('published', uri);
     }).catch(function (err) {
-      log.error('error publishing', uri, 'at', at, err.stack);
+      log.error('error publishing', uri, err.stack);
     });
+  } else {
+    promise = bluebird.resolve();
+  }
+
+  return promise;
 }
 
 /**
@@ -30,19 +94,14 @@ function publishPage(uri, at) {
  * @returns {Promise}
  */
 function publishByTime(list) {
-  const promises = [],
-    now = new Date().getTime();
-
   // list is assumed to be in order of when they should run
-  while (list.length && list[0][scheduledAtProperty] < now) {
-    let item = list.shift(),
-      at = item[scheduledAtProperty],
-      publish = item[publishProperty];
+  const promises = _.reduce(getPublishable(list, new Date().getTime()), function (promises, item) {
+    const uri = item.value[publishProperty];
 
-    if (publish.indexOf('/pages/')) {
-      promises.push(publishPage(publish, at));
-    }
-  }
+    promises.push(publish(uri).then(function () { return db.del(item.key); }));
+
+    return promises;
+  }, []);
 
   return bluebird.all(promises);
 }
@@ -55,7 +114,13 @@ function startListening() {
     interval = setInterval(function () {
       // get list for each site
       return _.map(siteService.sites(), function (site) {
-        return db.pipeToPromise(db.list({prefix: site.host + site.path + '/schedule'})).then(publishByTime);
+        return db.pipeToPromise(db.list({
+          prefix: site.host + site.path + '/schedule',
+          keys: true,
+          values: true,
+          isArray: true
+        })).then(JSON.parse)
+          .then(publishByTime);
       });
     }, intervalDelay);
   }
@@ -92,7 +157,7 @@ function create(uri, data) {
   reference = prefix + '/schedule/' + at.toString(36) + '-' +
     publish.replace(/[\/\.]/g, '-').replace(/-(?=-)/g, '');
 
-  return db.put(reference, data).then(function () {
+  return db.put(reference, JSON.stringify(data)).then(function () {
     return _.assign({_ref: reference}, data);
   });
 }
@@ -100,3 +165,4 @@ function create(uri, data) {
 module.exports.create = create;
 module.exports.startListening = startListening;
 module.exports.stopListening = stopListening;
+module.exports.setScheduleInterval = setScheduleInterval;

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var _ = require('lodash'),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./' + filename),
+  expect = require('chai').expect,
+  sinon = require('sinon'),
+  bluebird = require('bluebird'),
+  db = require('../services/db'),
+  log = require('../log'),
+  pages = require('../services/pages'),
+  siteService = require('../services/sites');
+
+describe(_.startCase(filename), function () {
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.useFakeTimers();
+    sandbox.stub(db, 'get');
+    sandbox.stub(db, 'put');
+    sandbox.stub(db, 'pipeToPromise');
+    sandbox.stub(pages, 'publish');
+    sandbox.stub(siteService, 'sites');
+    sandbox.stub(log, 'info');
+    sandbox.stub(log, 'error');
+  });
+
+  afterEach(function () {
+    lib.stopListening();
+    sandbox.restore();
+  });
+
+  describe('create', function () {
+    var fn = lib[this.title];
+
+    it('throws on missing "at" property', function () {
+      var ref = 'domain/pages/some-name',
+        data = {publish: 'abc'};
+
+      expect(function () {
+        fn(ref, data);
+      }).to.throw();
+    });
+
+    it('throws on missing "publish" property', function () {
+      var ref = 'domain/pages/some-name',
+        data = {at: 123};
+
+      expect(function () {
+        fn(ref, data);
+      }).to.throw();
+    });
+
+    it('schedules a publish of abc at 123', function () {
+      var ref = 'domain/pages/some-name',
+        data = {at: 123, publish: 'abc'};
+
+      db.put.returns(bluebird.resolve({}));
+
+      expect(function () {
+        fn(ref, data);
+      }).to.not.throw();
+    });
+  });
+
+  describe('startListening', function () {
+    var fn = lib[this.title];
+
+    it('publishes abc at 123', function (done) {
+      var data = {at: 123, publish: 'abc'};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve([data]));
+      pages.publish.returns(bluebird.resolve());
+
+      fn();
+
+      sandbox.clock.tick(60000);
+
+      _.defer(function () {
+        sinon.assert.calledWith(pages.publish, 'abc');
+        sinon.assert.calledWith(log.info, 'published', data.publish, 'at', data.at);
+        done();
+      });
+    });
+
+    it('logs error if failed to publish', function (done) {
+      var data = {at: 123, publish: 'abc'};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve([data]));
+      pages.publish.returns(bluebird.reject(new Error('')));
+
+      fn();
+
+      sandbox.clock.tick(60000);
+
+      _.defer(function () {
+        sinon.assert.calledWith(pages.publish, 'abc');
+        sinon.assert.calledOnce(log.error);
+        done();
+      });
+    });
+  });
+});

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -92,11 +92,10 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
+      log.info = function () {
         sinon.assert.calledWith(pages.publish, uri);
-        sinon.assert.calledWith(log.info, 'published', sinon.match.string);
         done();
-      });
+      };
     });
 
 
@@ -114,11 +113,10 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
+      log.info = function () {
         sinon.assert.calledWith(components.put, uri + '@published', componentData);
-        sinon.assert.calledWith(log.info, 'published', sinon.match.string);
         done();
-      });
+      };
     });
 
     it('logs error if failed to publish page', function (done) {
@@ -153,10 +151,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
-        sinon.assert.calledWith(log.error, sinon.match(/^Cannot parse JSON of/));
+      log.error = function () {
         done();
-      });
+      };
     });
 
     it('logs error if missing publish attribute', function (done) {
@@ -169,10 +166,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
-        sinon.assert.calledWith(log.error, sinon.match(/^Missing publish type/));
+      log.error = function () {
         done();
-      });
+      };
     });
 
     it('logs error if missing publish attribute', function (done) {
@@ -186,10 +182,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
-        sinon.assert.calledWith(log.error, sinon.match(/^Unknown publish type/));
+      log.error = function () {
         done();
-      });
+      };
     });
   });
 });

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -136,11 +136,10 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      _.defer(function () {
+      log.error = function () {
         sinon.assert.calledWith(pages.publish, uri);
-        sinon.assert.calledWith(log.error, 'error publishing', uri, sinon.match.string);
         done();
-      });
+      };
     });
 
     it('logs error if failed to parse JSON', function (done) {

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -3,26 +3,32 @@
 var _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
+  components = require('./components'),
   expect = require('chai').expect,
   sinon = require('sinon'),
   bluebird = require('bluebird'),
-  db = require('../services/db'),
+  db = require('./db'),
   log = require('../log'),
-  pages = require('../services/pages'),
-  siteService = require('../services/sites');
+  pages = require('./pages'),
+  siteService = require('./sites');
 
 describe(_.startCase(filename), function () {
-  var sandbox;
+  var sandbox,
+    intervalDelay = 100;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.useFakeTimers();
+    lib.setScheduleInterval(intervalDelay);
     sandbox.stub(db, 'get');
     sandbox.stub(db, 'put');
     sandbox.stub(db, 'pipeToPromise');
     sandbox.stub(pages, 'publish');
+    sandbox.stub(components, 'get');
+    sandbox.stub(components, 'put');
     sandbox.stub(siteService, 'sites');
     sandbox.stub(log, 'info');
+    sandbox.stub(log, 'warn');
     sandbox.stub(log, 'error');
   });
 
@@ -36,7 +42,7 @@ describe(_.startCase(filename), function () {
 
     it('throws on missing "at" property', function () {
       var ref = 'domain/pages/some-name',
-        data = {publish: 'abc'};
+        data = {publish: 'abcg'};
 
       expect(function () {
         fn(ref, data);
@@ -54,7 +60,7 @@ describe(_.startCase(filename), function () {
 
     it('schedules a publish of abc at 123', function () {
       var ref = 'domain/pages/some-name',
-        data = {at: 123, publish: 'abc'};
+        data = {at: 123, publish: 'abcf'};
 
       db.put.returns(bluebird.resolve({}));
 
@@ -67,38 +73,122 @@ describe(_.startCase(filename), function () {
   describe('startListening', function () {
     var fn = lib[this.title];
 
-    it('publishes abc at 123', function (done) {
-      var data = {at: 123, publish: 'abc'};
+    it('does not throw if started twice', function () {
+      expect(function () {
+        fn();
+        fn();
+      }).to.not.throw();
+    });
+
+    it('publishes page', function (done) {
+      var uri = 'abce/pages/abce',
+        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri})};
 
       siteService.sites.returns([{host: 'a', path: '/'}]);
-      db.pipeToPromise.returns(bluebird.resolve([data]));
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
       pages.publish.returns(bluebird.resolve());
 
       fn();
 
-      sandbox.clock.tick(60000);
+      sandbox.clock.tick(intervalDelay);
 
       _.defer(function () {
-        sinon.assert.calledWith(pages.publish, 'abc');
-        sinon.assert.calledWith(log.info, 'published', data.publish, 'at', data.at);
+        sinon.assert.calledWith(pages.publish, uri);
+        sinon.assert.calledWith(log.info, 'published', sinon.match.string);
         done();
       });
     });
 
-    it('logs error if failed to publish', function (done) {
-      var data = {at: 123, publish: 'abc'};
+
+    it('publishes component', function (done) {
+      var uri = 'abce/components/abce',
+        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri})},
+        componentData = {someData: 'someValue'};
 
       siteService.sites.returns([{host: 'a', path: '/'}]);
-      db.pipeToPromise.returns(bluebird.resolve([data]));
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
+      components.get.returns(bluebird.resolve(componentData));
+      components.put.returns(bluebird.resolve(componentData));
+
+      fn();
+
+      sandbox.clock.tick(intervalDelay);
+
+      _.defer(function () {
+        sinon.assert.calledWith(components.put, uri + '@published', componentData);
+        sinon.assert.calledWith(log.info, 'published', sinon.match.string);
+        done();
+      });
+    });
+
+    it('logs error if failed to publish page', function (done) {
+      bluebird.onPossiblyUnhandledRejection(function () {});
+      // rejection.suppressUnhandledRejections(); when bluebird supports it better
+
+      var uri = 'abce/pages/abcd',
+        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri})};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
       pages.publish.returns(bluebird.reject(new Error('')));
 
       fn();
 
-      sandbox.clock.tick(60000);
+      sandbox.clock.tick(intervalDelay);
 
       _.defer(function () {
-        sinon.assert.calledWith(pages.publish, 'abc');
-        sinon.assert.calledOnce(log.error);
+        sinon.assert.calledWith(pages.publish, uri);
+        sinon.assert.calledWith(log.error, 'error publishing', uri, sinon.match.string);
+        done();
+      });
+    });
+
+    it('logs error if failed to parse JSON', function (done) {
+      var uri = 'abce/pages/abcd',
+        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri}).substring(5)};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
+
+      fn();
+
+      sandbox.clock.tick(intervalDelay);
+
+      _.defer(function () {
+        sinon.assert.calledWith(log.error, sinon.match(/^Cannot parse JSON of/));
+        done();
+      });
+    });
+
+    it('logs error if missing publish attribute', function (done) {
+      var data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1})};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
+
+      fn();
+
+      sandbox.clock.tick(intervalDelay);
+
+      _.defer(function () {
+        sinon.assert.calledWith(log.error, sinon.match(/^Missing publish type/));
+        done();
+      });
+    });
+
+    it('logs error if missing publish attribute', function (done) {
+      var uri = 'abce/unknown/abcd',
+        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri})};
+
+      siteService.sites.returns([{host: 'a', path: '/'}]);
+      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
+
+      fn();
+
+      sandbox.clock.tick(intervalDelay);
+
+      _.defer(function () {
+        sinon.assert.calledWith(log.error, sinon.match(/^Unknown publish type/));
         done();
       });
     });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "New York Media",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9",
+    "bluebird": "^3.0",
     "body-parser": "^1.12",
     "chalk": "^1.0",
     "cuid": "^1.2.5",

--- a/test/api/schedule/delete.js
+++ b/test/api/schedule/delete.js
@@ -20,6 +20,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      sandbox.useFakeTimers();
       return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
     });
 

--- a/test/api/schedule/delete.js
+++ b/test/api/schedule/delete.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    var sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      componentData = {},
+      scheduleData = {},
+      layoutData = {},
+      pageData = {};
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/schedule', function () {
+      var path = this.title;
+
+      acceptsJson(path, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method DELETE not allowed' });
+      acceptsJsonBody(path, {}, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method DELETE not allowed' });
+      acceptsHtml(path, {}, 405, '405 Method DELETE not allowed');
+    });
+
+    describe('/schedule/:name', function () {
+      var path = this.title;
+
+      acceptsJson(path, {name: 'valid'}, 200, pageData);
+      acceptsJson(path, {name: 'missing'}, 404, { message: 'Not Found', code: 404 });
+
+      acceptsJsonBody(path, {name: 'valid'}, pageData, 200, pageData);
+      acceptsJsonBody(path, {name: 'missing'}, pageData, 404, { message: 'Not Found', code: 404 });
+
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+    });
+  });
+});

--- a/test/api/schedule/get.js
+++ b/test/api/schedule/get.js
@@ -19,6 +19,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      sandbox.useFakeTimers();
       return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
     });
 

--- a/test/api/schedule/get.js
+++ b/test/api/schedule/get.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    var sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      componentData = {},
+      scheduleData = {},
+      layoutData = {},
+      pageData = {};
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/schedule', function () {
+      var path = this.title;
+
+      acceptsJson(path, {}, 200, '[{"key":"localhost.example.com/schedule/valid","value":"{}"}]');
+      acceptsHtml(path, {}, 406);
+    });
+
+    describe('/schedule/:name', function () {
+      var path = this.title;
+
+      acceptsJson(path, {name: 'valid'}, 200, pageData);
+      acceptsJson(path, {name: 'missing'}, 404, { message: 'Not Found', code: 404 });
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+    });
+  });
+});

--- a/test/api/schedule/post.js
+++ b/test/api/schedule/post.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon'),
+  expect = require('chai').expect;
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    var sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      time = new Date('2015-01-01').getTime(),
+      componentData = {},
+      scheduleData = {},
+      layoutData = {},
+      pageData = {};
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/schedule', function () {
+      var path = this.title;
+
+      acceptsJson(path, {}, 400, { message: 'Missing "at" property as number.', code: 400 });
+      acceptsHtml(path, {}, 406, '406 text/html not acceptable');
+
+      acceptsJsonBody(path, {}, _.assign({}, pageData), 400, { message: 'Missing "at" property as number.', code: 400 });
+      acceptsJsonBody(path, {}, _.assign({at: time}, pageData), 400, { message: 'Missing "publish" property as string.', code: 400 });
+      acceptsJsonBody(path, {}, _.assign({at: time, publish: 'abc'}, pageData), 201, { _ref: 'localhost.example.com/schedule/i4dd91c0-abc', at: time, publish: 'abc' });
+    });
+
+    describe('/schedule/:name', function () {
+      var path = this.title;
+
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'delete'], code: 405, message: 'Method POST not allowed' });
+      acceptsJsonBody(path, {name: 'valid'}, pageData, 405, { allow:['get', 'delete'], code: 405, message: 'Method POST not allowed' });
+      acceptsHtml(path, {name: 'valid'}, 405, '405 Method POST not allowed');
+    });
+  });
+});

--- a/test/api/schedule/post.js
+++ b/test/api/schedule/post.js
@@ -4,8 +4,7 @@ var _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  sinon = require('sinon'),
-  expect = require('chai').expect;
+  sinon = require('sinon');
 
 describe(endpointName, function () {
   describe(filename, function () {
@@ -22,6 +21,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      sandbox.useFakeTimers();
       return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
     });
 

--- a/test/api/schedule/put.js
+++ b/test/api/schedule/put.js
@@ -20,6 +20,7 @@ describe(endpointName, function () {
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      sandbox.useFakeTimers();
       return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
     });
 

--- a/test/api/schedule/put.js
+++ b/test/api/schedule/put.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    var sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      componentData = {},
+      scheduleData = { at: new Date('2015-01-01').getTime() },
+      layoutData = {},
+      pageData = {};
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      return apiAccepts.beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/schedule', function () {
+      var path = this.title;
+
+      acceptsJson(path, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {}, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsHtml(path, {}, 405, '405 Method PUT not allowed');
+    });
+
+    describe('/schedule/:name', function () {
+      var path = this.title;
+
+      acceptsJson(path, {}, 405, { allow:['get', 'delete'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {}, {}, 405, { allow:['get', 'delete'], code: 405, message: 'Method PUT not allowed' });
+      acceptsHtml(path, {}, 405, '405 Method PUT not allowed');
+    });
+  });
+});

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -493,6 +493,32 @@ function beforeEachPageTest(sandbox, hostname, pageData, layoutData, firstLevelC
  *
  * @param sandbox
  * @param hostname
+ * @param pageData
+ * @param layoutData
+ * @param componentData
+ * @param scheduleData
+ * @returns {Promise}
+ */
+function beforeEachScheduleTest(sandbox, hostname, pageData, layoutData, componentData, scheduleData) {
+  return beforeEachTest({
+    sandbox: sandbox,
+    hostname: hostname,
+    pathsAndData: {
+      '/components/layout': layoutData,
+      '/components/valid': componentData,
+      '/pages/valid': pageData,
+      '/schedule/valid': scheduleData
+    }
+  });
+}
+
+/**
+ * Before each test, make the DB and Host consistent, and get a _new_ version of express.
+ *
+ * Yes, brand new, for every single test.
+ *
+ * @param sandbox
+ * @param hostname
  * @param data
  * @returns {Promise}
  */
@@ -546,5 +572,6 @@ module.exports.expectDataPlusRef = expectDataPlusRef;
 module.exports.beforeTesting = beforeTesting;
 module.exports.beforeEachComponentTest = beforeEachComponentTest;
 module.exports.beforeEachPageTest = beforeEachPageTest;
+module.exports.beforeEachScheduleTest = beforeEachScheduleTest;
 module.exports.beforeEachUriTest = beforeEachUriTest;
 module.exports.beforeEachListTest = beforeEachListTest;


### PR DESCRIPTION
New Feature
- Add `/schedule` endpoint that:
  - accepts POST at `/schedule` with `{at: <timestamp>, publish: <page or component uri>}` returning `{at: <timestamp>, publish: <page or component uri>, _ref: <new id uri>}`
  - accepts GET at `/schedule` and `/schedule/:id`
  - accepts DELETE at `/schedule/:id`