### PR TITLE
pass-task

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -365,19 +365,28 @@ function getExpressRoutePrefix(site) {
  * @param {function} next
  */
 function renderExpressRoute(req, res, next) {
-  var site, prefix, pageReference;
+  var site, prefix, pageReference, hrStart;
 
+  hrStart = process.hrtime()[1];
   site = res.locals.site;
   prefix = getExpressRoutePrefix(site) + '/uris/';
   pageReference = prefix + new Buffer(req.hostname + req.baseUrl + req.path).toString('base64');
 
-  renderUri(pageReference, res)
-    .then(function (html) {
-      res.type('html');
-      res.send(html);
-    }).catch(function (err) {
+  renderUri(pageReference, res).then(function (html) {
+    res.type('html');
+    res.send(html);
+
+    log.info('rendered express route:' +
+      (req.hostname + req.baseUrl + req.path) + ' ' +
+      ((process.hrtime()[1] - hrStart) / 1000000) + 'ms'
+    );
+  }).catch(function (err) {
+    if (err.name === 'NotFoundError') {
+      next();
+    } else {
       next(err);
-    });
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
Patch
- Report what was rendered and how long it took using `hrtime`.
- Pass composer-level route with `next()` if NotFoundError