### PR TITLE
resolve-media-map

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -18,10 +18,10 @@ reporting:
         - lcov
     dir: ./coverage
     watermarks:
-        statements: [80, 90]
-        lines: [80, 90]
-        functions: [80, 90]
-        branches: [50, 80]
+        statements: [98, 100]
+        lines: [98, 100]
+        functions: [98, 100]
+        branches: [98, 100]
     report-config:
         clover: {file: clover.xml}
         cobertura: {file: cobertura-coverage.xml}
@@ -38,10 +38,10 @@ hooks:
     handle-sigint: false
 check:
     global:
-        statements: 99
-        lines: 99
-        branches: 98
-        functions: 99
+        statements: 100
+        lines: 100
+        branches: 100
+        functions: 100
         excludes: []
     each:
         statements: 0

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -87,12 +87,17 @@ function addComponentList(ref, data) {
 /**
  *
  * @param {Array} componentList
- * @param {object} site
  * @param {object} data
+ * @param {object} locals
  * @returns {{styles: Array, scripts: Array}}
  */
-function addMediaMap(componentList, site, data) {
-  var mediaMap = media.getMediaMap(componentList, site.slug);
+function addMediaMap(componentList, data, locals) {
+  var site = locals.site,
+    mediaMap = media.getMediaMap(componentList, site.slug);
+
+  if (_.isFunction(site.resolveMedia)) {
+    mediaMap = site.resolveMedia(mediaMap, locals) || mediaMap;
+  }
 
   if (mediaMap.styles.length > 0 || mediaMap.scripts.length > 0) {
     _.set(data, media.mediaMapProperty, mediaMap);
@@ -128,7 +133,7 @@ function applyOptions(options, res) {
       componentList = addComponentList(options.layoutRef || options.ref, result);
 
       if (componentList.length) {
-        addMediaMap(componentList, site, result);
+        addMediaMap(componentList, result, locals);
       }
     }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,6 +17,16 @@ var uriRoutes,
   components = require('./services/components'),
   control = require('./control');
 
+
+/**
+ * Internal function to get data
+ * @param {string} uri
+ * @returns {Promise}
+ */
+function getDBObject(uri) {
+  return db.get(uri).then(JSON.parse);
+}
+
 /**
  * Find all _ref, and recursively expand them.
  *
@@ -24,23 +34,17 @@ var uriRoutes,
  * @param {function|string} [filter='_ref']
  * @returns {Promise}
  */
-function resolveDataReferences(data, filter) {
+function resolveComponentReferences(data, filter) {
   var referenceProperty = '_ref',
     referenceObjects = _.listDeepObjects(data, filter || referenceProperty);
 
-  return bluebird.all(referenceObjects).each(function (placeholder) {
-    var promise,
-      ref = placeholder[referenceProperty],
-      handler = _.find(uriRoutes, function (item) { return ref.match(item.when); });
-
-    promise = handler.json(placeholder[referenceProperty]);
-
-    return promise.then(function (obj) {
-        // the thing we got back might have its own references
-        return resolveDataReferences(obj, filter).finally(function () {
-          _.assign(placeholder, _.omit(obj, referenceProperty));
-        });
+  return bluebird.all(referenceObjects).each(function (referenceObject) {
+    return components.get(referenceObject[referenceProperty]).then(function (obj) {
+      // the thing we got back might have its own references
+      return resolveComponentReferences(obj, filter).finally(function () {
+        _.assign(referenceObject, _.omit(obj, referenceProperty));
       });
+    });
   }).return(data);
 }
 
@@ -85,28 +89,6 @@ function addComponentList(ref, data) {
 }
 
 /**
- *
- * @param {Array} componentList
- * @param {object} data
- * @param {object} locals
- * @returns {{styles: Array, scripts: Array}}
- */
-function addMediaMap(componentList, data, locals) {
-  var site = locals.site,
-    mediaMap = media.getMediaMap(componentList, site.slug);
-
-  if (_.isFunction(site.resolveMedia)) {
-    mediaMap = site.resolveMedia(mediaMap, locals) || mediaMap;
-  }
-
-  if (mediaMap.styles.length > 0 || mediaMap.scripts.length > 0) {
-    _.set(data, media.mediaMapProperty, mediaMap);
-  }
-
-  return mediaMap;
-}
-
-/**
  * Add state to result, which adds functionality and information about this request to the templates.
  * @param options
  * @param res
@@ -128,13 +110,10 @@ function applyOptions(options, res) {
     transfer(options, result, 'version', '_version');
     transfer(options, result, 'layout', '_layout');
 
-    // don't assume ref
-    if (options.ref) {
-      componentList = addComponentList(options.layoutRef || options.ref, result);
+    componentList = addComponentList(options.layoutRef || options.ref, result);
 
-      if (componentList.length) {
-        addMediaMap(componentList, result, locals);
-      }
+    if (componentList.length) {
+      media.addMediaMap(componentList, result, locals);
     }
 
     // options are done at this point; now mix with the data and bind into a self-referencing chain of globals
@@ -179,7 +158,7 @@ function renderTemplate() {
  * @returns {Promise}
  */
 function renderByConfiguration(options, res) {
-  return resolveDataReferences(options.data)
+  return resolveComponentReferences(options.data)
     .then(applyOptions(options, res))
     .then(renderTemplate());
 }
@@ -214,7 +193,7 @@ function renderComponent(uri, res, options) {
  * @returns {{_ref: string}}
  */
 function refToObj(ref) {
-  return { _ref: ref };
+  return {_ref: ref};
 }
 
 /**
@@ -290,15 +269,8 @@ function mapLayoutToPageData(pageData, layoutData) {
  * @example renderPage('/pages/bG9jYWxob3N0LnZ1bHR1cmUuY29tL2Zhdmljb24uaWNv', res);
  */
 function renderPage(uri, res) {
-
-  // ignore version if they are editing; default to 'published'
-  if (res.req.query.edit && uri.split('@')[1]) {
-    throw new Error('Client: Cannot edit versioned page.');
-  }
-
   // look up page alias' component instance
-  return db.get(uri)
-    .then(JSON.parse)
+  return getDBObject(uri)
     .then(function (result) {
       var layoutReference = result.layout,
         layoutComponentName = components.getName(layoutReference),
@@ -307,7 +279,7 @@ function renderPage(uri, res) {
       return components.get(layoutReference)
         .then(mapLayoutToPageData.bind(this, pageData))
         .then(function (result) {
-          var options = { data: result };
+          var options = {data: result};
           options.version = uri.split('@')[1];
           options.data.template = layoutComponentName;
           options.pageRef = uri;
@@ -329,18 +301,17 @@ function renderPage(uri, res) {
  * @returns Promise
  */
 function renderUri(uri, res) {
-  return db.get(uri)
-    .then(function (result) {
-      var route = _.find(uriRoutes, function (item) {
-        return result.match(item.when);
-      });
-
-      if (route) {
-        return route.html(result, res);
-      } else {
-        throw new Error('Invalid URI: ' + uri + ': ' + result);
-      }
+  return db.get(uri).then(function (result) {
+    const route = _.find(uriRoutes, function (item) {
+      return result.match(item.when);
     });
+
+    if (route) {
+      return route.html(result, res);
+    } else {
+      throw new Error('Invalid URI: ' + uri + ': ' + result);
+    }
+  });
 }
 
 /**
@@ -402,18 +373,26 @@ function setUriRouteHandlers(value) {
 }
 
 /**
- * Internal function to get data
- * @param uri
- * @returns {Promise.object}
+ * Assume they're talking about published content unless ?edit
+ *
+ * NOTE:  This probably shouldn't be our responsibility
+ *
+ * @param {function} fn
+ * @returns {function}
  */
-function getPageData(uri) {
-  return db.get(uri).then(JSON.parse);
+function assumePublishedUnlessEditing(fn) {
+  return function (uri, res) {
+    // ignore version if they are editing; default to 'published'
+    if (!_.get(res, 'req.query.edit')) {
+      uri = references.replaceVersion(uri, uri.split('@')[1] || 'published');
+    }
+
+    return fn(uri, res);
+  };
 }
 
 /**
- * Reset our route handlers back to the standard.
- *
- * NOTE: Our default route handlers are defined here.
+ * Uris route as following
  */
 function resetUriRouteHandlers() {
   /**
@@ -421,23 +400,20 @@ function resetUriRouteHandlers() {
    * @type {[{when: RegExp, html: function, json: function}]}
    */
   uriRoutes = [
+    // assume published
     {
       when: /\/pages\//,
-      html: function (uri, res) {
-
-        // ignore version if they are editing; default to 'published'
-        if (!res.req.query.edit) {
-          uri = references.replaceVersion(uri, uri.split('@')[1] || 'published');
-        }
-
-        return renderPage(uri, res);
-      },
-      json: getPageData
-    }, {
+      html: assumePublishedUnlessEditing(renderPage),
+      json: assumePublishedUnlessEditing(getDBObject)
+    },
+    // assume published
+    {
       when: /\/components\//,
-      html: renderComponent,
-      json: components.get
-    }, {
+      html: assumePublishedUnlessEditing(renderComponent),
+      json: assumePublishedUnlessEditing(components.get)
+    },
+    // uris are not published, they only exist
+    {
       when: /\/uris\//,
       html: renderUri,
       json: db.get
@@ -464,4 +440,4 @@ module.exports.addEngines = addEngines;
 // for testing (or maybe from a config later?)
 module.exports.setUriRouteHandlers = setUriRouteHandlers;
 module.exports.resetUriRouteHandlers = resetUriRouteHandlers;
-module.exports.resolveDataReferences = resolveDataReferences;
+module.exports.resolveComponentReferences = resolveComponentReferences;

--- a/lib/composer.test.js
+++ b/lib/composer.test.js
@@ -318,7 +318,6 @@ describe(_.startCase(filename), function () {
       components.get.withArgs('/c/e').returns(bluebird.resolve({i: 'j'}));
 
       return fn(data).then(function (result) {
-        console.log('  final result', result);
         expect(result).to.deep.equal({
           a: { _ref: '/c/b', g: 'h' },
           c: { d: { _ref: '/c/e', i: 'j' } }

--- a/lib/composer.test.js
+++ b/lib/composer.test.js
@@ -1,5 +1,5 @@
 'use strict';
-var _ = require('lodash'),
+const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   expect = require('chai').expect,
   sinon = require('sinon'),
@@ -31,7 +31,7 @@ describe(_.startCase(filename), function () {
    * @returns {object}
    */
   function getMockRes(fn) {
-    var res = createMockRes(),
+    const res = createMockRes(),
       req = createMockReq();
 
     res.req = req;
@@ -94,7 +94,7 @@ describe(_.startCase(filename), function () {
   }
 
   describe('renderComponent', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('throws if data not found, no logging', function (done) {
       components.get.returns(bluebird.reject(new Error('thing')));
@@ -138,7 +138,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('sets site query param', function () {
-      var res = getMockRes(),
+      const res = getMockRes(),
         mockSiteName = 'otherSite',
         mockQuery = {site: mockSiteName};
 
@@ -157,10 +157,10 @@ describe(_.startCase(filename), function () {
   });
 
   describe('renderPage', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('follows the basic process', function () {
-      var res = getMockRes();
+      const res = getMockRes();
 
       // THIS IS WHAT WE EXPECT FROM THE BASIC PROCESS:
 
@@ -187,7 +187,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('allows arrays in page data with components on either side in layout', function () {
-      var pageRef = '/pages/whatever',
+      const pageRef = '/pages/whatever',
         layoutRef = '/components/hey',
         layoutData = {areaA: [{_ref: '/components/c'}, 'head', {_ref: '/components/d'}]},
         pageData = {layout: layoutRef, head: ['/components/a', '/components/b']},
@@ -217,7 +217,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('warns if missing reference in layout', function () {
-      var pageRef = '/pages/whatever',
+      const pageRef = '/pages/whatever',
         layoutRef = '/components/hey',
         layoutData = {areaA: ['head']},
         pageData = {layout: layoutRef},
@@ -234,7 +234,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('warns if data in page is not a reference', function () {
-      var pageRef = '/pages/whatever',
+      const pageRef = '/pages/whatever',
         layoutRef = '/components/hey',
         layoutData = {areaA: ['head']},
         pageData = {layout: layoutRef, head: {}},
@@ -258,7 +258,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('renderUri', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('uses uri route if matching', function () {
       var resultRef = 'whatever or something';
@@ -281,7 +281,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('throws if no matching uri route', function (done) {
-      var resultRef = 'whatever or something';
+      const resultRef = 'whatever or something';
 
       // when we find the new reference
       db.get.returns(bluebird.resolve(resultRef));
@@ -301,26 +301,24 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  describe('resolveDataReferences', function () {
-    var fn = lib[this.title];
+  describe('resolveComponentReferences', function () {
+    const fn = lib[this.title];
 
     beforeEach(function () {
-      lib.setUriRouteHandlers([{
-        when: /^\/c\//,
-        json: function (ref) { return db.get(ref).then(JSON.parse); }
-      }]);
+
     });
 
     it('looks up references', function () {
-      var data = {
+      const data = {
           a: {_ref:'/c/b'},
           c: {d: {_ref:'/c/e'}}
         };
 
-      db.get.withArgs('/c/b').returns(resolveString({g: 'h'}));
-      db.get.withArgs('/c/e').returns(resolveString({i: 'j'}));
+      components.get.withArgs('/c/b').returns(bluebird.resolve({g: 'h'}));
+      components.get.withArgs('/c/e').returns(bluebird.resolve({i: 'j'}));
 
       return fn(data).then(function (result) {
+        console.log('  final result', result);
         expect(result).to.deep.equal({
           a: { _ref: '/c/b', g: 'h' },
           c: { d: { _ref: '/c/e', i: 'j' } }
@@ -331,14 +329,14 @@ describe(_.startCase(filename), function () {
     });
 
     it('looks up references recursively', function () {
-      var data = {
+      const data = {
           a: {_ref:'/c/b'},
           c: {d: {_ref:'/c/e'}}
         };
 
-      db.get.withArgs('/c/b').returns(resolveString({g: 'h'}));
-      db.get.withArgs('/c/e').returns(resolveString({i: 'j', k: {_ref:'/c/m'}}));
-      db.get.withArgs('/c/m').returns(resolveString({n: 'o'}));
+      components.get.withArgs('/c/b').returns(bluebird.resolve({g: 'h'}));
+      components.get.withArgs('/c/e').returns(bluebird.resolve({i: 'j', k: {_ref:'/c/m'}}));
+      components.get.withArgs('/c/m').returns(bluebird.resolve({n: 'o'}));
 
       return fn(data).then(function (result) {
         expect(result).to.deep.equal({
@@ -359,7 +357,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('addEngines', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('sets engines', function () {
       expect(function () {
@@ -369,7 +367,7 @@ describe(_.startCase(filename), function () {
   });
 
   it('gets page without query string', function (done) {
-    var res = getMockRes(done.bind(null, 'should throw')),
+    const res = getMockRes(done.bind(null, 'should throw')),
       req = res.req,
       expectedUri = 'example.com/someUrl',
       pathOnBase64 = 'example.com/uris/' + new Buffer(expectedUri).toString('base64');
@@ -392,7 +390,7 @@ describe(_.startCase(filename), function () {
   });
 
   it('renders page after following uri', function (done) {
-    var res = getMockRes(function () { done(); }),
+    const res = getMockRes(function () { done(); }),
       expectedUri = 'example.com/someUrl',
       pathOnBase64 = 'example.com/uris/' + new Buffer(expectedUri).toString('base64'),
       template = '...';
@@ -407,7 +405,7 @@ describe(_.startCase(filename), function () {
   });
 
   it('renders page with a path', function (done) {
-    var res = getMockRes(function () { done(); }),
+    const res = getMockRes(function () { done(); }),
       expectedUri = 'example.com/some-path/someUrl',
       pathOnBase64 = 'example.com/some-path/uris/' + new Buffer(expectedUri).toString('base64'),
       template = '...';
@@ -421,5 +419,37 @@ describe(_.startCase(filename), function () {
     plex.render.returns('<thing></thing>');
 
     lib(res.req, res, done.bind(null, 'should not throw'));
+  });
+
+  it('skips page that is not found, looking for next route', function (done) {
+    const res = getMockRes(),
+      expectedUri = 'example.com/some-path/someUrl',
+      pathOnBase64 = 'example.com/some-path/uris/' + new Buffer(expectedUri).toString('base64'),
+      error = new Error();
+
+    error.name = 'NotFoundError';
+    res.req.baseUrl = '/some-path';
+    res.locals.site.path = '/some-path';
+    db.get.withArgs(pathOnBase64).returns(bluebird.reject(error));
+
+    lib(res.req, res, done);
+  });
+
+  it('renders latest page if editing', function (done) {
+    const res = getMockRes(function () { done(); }),
+      expectedUri = 'example.com/some-path/someUrl',
+      pathOnBase64 = 'example.com/some-path/uris/' + new Buffer(expectedUri).toString('base64'),
+      template = '...';
+
+    res.req.baseUrl = '/some-path';
+    res.req.query = {edit: 'whatever'};
+    res.locals.site.path = '/some-path';
+    db.get.withArgs(pathOnBase64).returns(bluebird.resolve('example.com/some-path/pages/a'));
+    db.get.withArgs('example.com/some-path/pages/a').returns(resolveString({layout: 'example.com/some-path/components/b'}));
+    components.get.withArgs('example.com/some-path/components/b').returns(bluebird.resolve({}));
+    components.getTemplate.returns(template);
+    plex.render.returns('<thing></thing>');
+
+    lib(res.req, res, done);
   });
 });

--- a/lib/media.js
+++ b/lib/media.js
@@ -134,6 +134,38 @@ function getMediaMap(componentList, slug) {
   };
 }
 
+/**
+ *
+ * @param {Array} componentList
+ * @param {object} data
+ * @param {object} locals
+ * @param {object} locals.site
+ * @returns {{styles: Array, scripts: Array}}
+ */
+function addMediaMap(componentList, data, locals) {
+  var site, mediaMap;
+
+  if (!_.has(locals, 'site.slug')) {
+    console.log('locals', locals);
+    throw new TypeError('Locals with site slug are required to add media map.');
+  }
+
+  site = locals.site;
+  mediaMap = getMediaMap(componentList, site.slug);
+
+  // allow site to change the media map before applying it
+  if (_.isFunction(site.resolveMedia)) {
+    mediaMap = site.resolveMedia(mediaMap, locals) || mediaMap;
+  }
+
+  // add the lists of media to the data to be processed
+  if (mediaMap.styles.length > 0 || mediaMap.scripts.length > 0) {
+    data[mediaMapProperty] = mediaMap;
+  }
+
+  return mediaMap;
+}
+
 module.exports.append = append;
 module.exports.getMediaMap = getMediaMap;
-module.exports.mediaMapProperty = mediaMapProperty;
+module.exports.addMediaMap = addMediaMap;

--- a/lib/media.js
+++ b/lib/media.js
@@ -2,8 +2,13 @@
 
 var _ = require('lodash'),
   components = require('./services/components'),
-  mediaMapProperty = '_mediaMap';
+  mediaMapProperty = 'media';
 
+/**
+ * @param {Array} list
+ * @param {function} fn
+ * @returns {Array}
+ */
 function flatMap(list, fn) {
   return _.filter(_.flattenDeep(_.map(list, fn)), _.identity);
 }
@@ -88,6 +93,10 @@ function appendMediaToBottom(mediaMap, html) {
   return splice(html, index, items);
 }
 
+/**
+ * @param {object} data
+ * @returns {object}
+ */
 function append(data) {
   var mediaMap = data[mediaMapProperty],
     tasks = [];
@@ -115,17 +124,14 @@ function append(data) {
  * @returns {{styles: Array, scripts: Array}}
  */
 function getMediaMap(componentList, slug) {
-  var mediaMap = {};
-
-  mediaMap.styles = flatMap(componentList, function (component) {
-    return components.getStyles(component, slug);
-  });
-
-  mediaMap.scripts = flatMap(componentList, function (component) {
-    return components.getScripts(component, slug);
-  });
-
-  return mediaMap;
+  return {
+    styles: flatMap(componentList, function (component) {
+      return components.getStyles(component, slug);
+    }),
+    scripts: flatMap(componentList, function (component) {
+      return components.getScripts(component, slug);
+    })
+  };
 }
 
 module.exports.append = append;

--- a/lib/media.js
+++ b/lib/media.js
@@ -146,7 +146,6 @@ function addMediaMap(componentList, data, locals) {
   var site, mediaMap;
 
   if (!_.has(locals, 'site.slug')) {
-    console.log('locals', locals);
     throw new TypeError('Locals with site slug are required to add media map.');
   }
 

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -31,15 +31,13 @@ describe(_.startCase(filename), function () {
    * @returns {{}}
    */
   function mediaMap(obj) {
-    var container = {};
-
-    container[lib.mediaMapProperty] = obj;
-
-    return container;
+    return {
+      media: obj
+    };
   }
 
   describe('append', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('adds nothing to bottom of head when no styles', function () {
       components.getStyles.onCall(0).returns([]);
@@ -91,7 +89,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('getMediaMap', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('accepts empty list, empty slug', function () {
       expect(fn([])).to.deep.equal({scripts: [], styles: []});
@@ -137,6 +135,94 @@ describe(_.startCase(filename), function () {
       components.getStyles.withArgs('c', undefined).returns(['/e/c', '/e/cc']);
 
       expect(fn(['a', 'b', 'c'], 'd')).to.deep.equal({scripts: [], styles: ['/e/aa', '/e/b', '/e/bb']});
+    });
+  });
+
+  describe('addMediaMap', function () {
+    const fn = lib[this.title];
+
+    it('throws if missing locals.site.slug', function () {
+      var componentList = [],
+        data = {},
+        locals = {site: {}};
+
+      expect(function () {
+        fn(componentList, data, locals);
+      }).to.throw(TypeError);
+    });
+
+    it('does not set media if missing components', function () {
+      var componentList = [],
+        data = {},
+        locals = {site: {slug: 'hey'}};
+
+      fn(componentList, data, locals);
+
+      expect(data.media).to.equal(undefined);
+    });
+
+    it('sets media if components have styles and scripts', function () {
+      var siteName = 'some site',
+        componentList = ['a', 'e'],
+        data = {},
+        locals = {site: {slug: siteName}};
+
+      components.getScripts.withArgs('a', siteName).returns(['/c/d']);
+      components.getStyles.withArgs('e', siteName).returns(['/f/g']);
+
+      fn(componentList, data, locals);
+
+      expect(data.media).to.deep.equal({
+        styles: ['/f/g'],
+        scripts: ['/c/d']
+      });
+    });
+
+    it('allows user to set own media', function () {
+      var siteName = 'some site',
+        componentList = ['a', 'e'],
+        data = {},
+        locals = {site: {
+          slug: siteName,
+          resolveMedia: function () {
+            return {
+              scripts: ['/f/g'],
+              styles: ['/c/d']
+            };
+          }
+        }};
+
+      components.getScripts.withArgs('a', siteName).returns(['/h/i']);
+      components.getStyles.withArgs('e', siteName).returns(['/j/k']);
+
+      fn(componentList, data, locals);
+
+      expect(data.media).to.deep.equal({
+        scripts: ['/f/g'],
+        styles: ['/c/d']
+      });
+    });
+
+    it('allows user to set own media by editing arrays in-place', function () {
+      var siteName = 'some site',
+        componentList = ['a', 'e'],
+        data = {},
+        locals = {site: {
+          slug: siteName,
+          resolveMedia: function (media) {
+            media.scripts.push('/x/y');
+          }
+        }};
+
+      components.getScripts.withArgs('a', siteName).returns(['/h/i']);
+      components.getStyles.withArgs('e', siteName).returns(['/j/k']);
+
+      fn(componentList, data, locals);
+
+      expect(data.media).to.deep.equal({
+        styles: ['/j/k'],
+        scripts: ['/h/i', '/x/y']
+      });
     });
   });
 });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -20,24 +20,6 @@ const _ = require('lodash'),
       'X-Forwarded-For', 'X-Forwarded-Host', 'X-Forwarded-Proto'].join(',')
   };
 
-
-/**
- * Get site from options, verify its real, throw if not.
- *
- * @param {object} options
- * @throws Error if not a real site
- * @returns {object}
- */
-function getSite(options) {
-  var site = siteService.sites()[options.slug];
-
-  if (!site) {
-    throw new Error('Client: Invalid site ' + options.slug);
-  }
-
-  return site;
-}
-
 /**
  * Add site.slug to locals for each site
  *
@@ -90,22 +72,22 @@ function addUri(req, res, next) {
 function addControllerRoutes(router) {
   var routesPath = '/routes';
 
-  // assume json for anything in request bodies
-  router.use(require('body-parser').json({strict: true, type: 'application/json'}));
-  router.use(require('body-parser').text({type: 'text/*'}));
-
   // load all controller routers
   _.each(files.getFiles(__dirname + routesPath), function (filename) {
-    var pathContainer,
+    var pathRouter,
       name = responses.removeExtension(filename),
       controller = files.tryRequire('.' + routesPath + '/' + name);
 
-    // we're okay with an error occuring here because it means we're missing something important in a route
+    // we're okay with an error occurring here because it means we're missing something important in a route
+    pathRouter = express.Router();
 
-    pathContainer = express.Router();
-    controller(pathContainer);
+    // assume json or text for anything in request bodies
+    pathRouter.use(require('body-parser').json({strict: true, type: 'application/json'}));
+    pathRouter.use(require('body-parser').text({type: 'text/*'}));
 
-    router.use('/' + name, pathContainer);
+    controller(pathRouter);
+
+    router.use('/' + name, pathRouter);
   });
 }
 
@@ -134,16 +116,37 @@ function addCORS(site) {
 }
 
 /**
+ * Default way to load site controllers.
  *
  * @param {express.Router} router
- * @param {object} options
+ * @param {object} site
+ * @returns {express.Router}
  */
-function addSite(router, options) {
-  options = _.defaults(options, {
-    path: '/'
-  });
-  var path = options.path,
-    site = getSite(options),
+function addSiteController(router, site) {
+  if (site.dir) {
+    const controller = files.tryRequire(site.dir);
+
+    if (controller) {
+      if (_.isFunction(controller)) {
+        controller(router, composer, site);
+      }
+
+      if (_.isFunction(controller.resolveMedia)) {
+        site.resolveMedia = controller.resolveMedia;
+      }
+    }
+  }
+
+  return router;
+}
+
+/**
+ * @param {express.Router} router
+ * @param {object} site
+ */
+function addSite(router, site) {
+  site = _.defaults(site, { path: '/' });
+  const path = site.path,
     siteRouter = express.Router();
 
   siteRouter.use(addUri);
@@ -152,9 +155,7 @@ function addSite(router, options) {
   siteRouter.use(addCORS(site));
 
   // optional module to load routes and configuration defined from outside of amphora
-  if (options.siteResolver) {
-    router.use(path, options.siteResolver(siteRouter, options));
-  }
+  router.use(path, addSiteController(siteRouter, site));
 
   // components, pages and schema added last so they can change things about the routes for additional functionality
   addControllerRoutes(siteRouter);
@@ -187,31 +188,15 @@ function sortByDepthOfPath(a, b) {
  *  }
  */
 function getDefaultSiteSettings(hostname) {
-  var name = _.takeRight(hostname.split('.'), 2)[0]; // penultimate or last
+  const name = _.takeRight(hostname.split('.'), 2)[0]; // penultimate or last
 
   return {
     slug: name.toLowerCase(),
     name: _.startCase(name),
     host: hostname,
-    path: '/'
+    path: '/',
+    assetDir: 'public'
   };
-}
-
-/**
- * Default way to load site controllers.
- *
- * @param {express.Router} router
- * @param {object} data  Extra information to help load controllers
- * @returns {express.Router}
- */
-function resolveSiteController(router, data) {
-  var controller = files.tryRequire(data.dir);
-
-  if (controller) {
-    controller(router, composer);
-  }
-
-  return router;
 }
 
 /**
@@ -237,21 +222,15 @@ function vhost(hostname, router) {
 /**
  * @param {express.Router} router
  * @param {string} hostname
- * @param {object} [options]
- * @param {array} [options.sites]
- * @param {object} [options.siteResolver] Site router
+ * @param {Array} [sites]  Within a host, there can exist many sites at different paths
  *
  * @example addHost('www.example.com');
  */
-function addHost(router, hostname, options) {
-  options = options || {};
-  var hostRouter = express.Router(),
-    sites = options.sites || [getDefaultSiteSettings(hostname)];
+function addHost(router, hostname, sites) {
+  sites = sites || [getDefaultSiteSettings(hostname)];
+  var hostRouter = express.Router();
 
-  _.each(sites, function (site) {
-    // pass whatever options were given for the host, plus any extra information for the site.
-    addSite(hostRouter, _.defaults(site, _.omit(options, 'sites'))); //prevent circular reference
-  });
+  _.each(sites, addSite.bind(null, hostRouter));
 
   // once all sites are added, wrap them in a vhost
   router.use(vhost(hostname, hostRouter));
@@ -272,10 +251,7 @@ function loadFromConfig(router) {
   _.each(siteHosts, function (hostname) {
     var sites = _.filter(sitesMap, {host: hostname}).sort(sortByDepthOfPath);
 
-    addHost(router, hostname, {
-      sites: sites,
-      siteResolver: resolveSiteController
-    });
+    addHost(router, hostname, sites);
   });
   return router;
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -131,9 +131,8 @@ function addSiteController(router, site) {
         controller(router, composer, site);
       }
 
-      if (_.isFunction(controller.resolveMedia)) {
-        site.resolveMedia = controller.resolveMedia;
-      }
+      // things to remember from controller
+      _.assign(site, _.pick(controller, 'resolveMedia'));
     }
   }
 
@@ -262,3 +261,4 @@ module.exports.addHost = addHost;
 module.exports.getDefaultSiteSettings = getDefaultSiteSettings;
 module.exports.sortByDepthOfPath = sortByDepthOfPath;
 module.exports.addCORS = addCORS;
+module.exports.addSiteController = addSiteController;

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -84,6 +84,7 @@ describe(_.startCase(filename), function () {
     it('www.example.com', function () {
       var hostname = 'www.example.com';
       expect(fn(hostname)).to.deep.equal({
+        assetDir: 'public',
         host: hostname,
         name: 'Example',
         path: '/',
@@ -101,21 +102,18 @@ describe(_.startCase(filename), function () {
 
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
+      sandbox.stub(files, 'getFiles');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
-      siteService.sites.returns({example: {
-        slug: 'example',
-        assetDir: 'example'
-      }});
+      files.tryRequire.returns(_.noop);
+      files.getFiles.returns(['a.b, c.d, e.f']);
 
-      // checking for the files to use as controllers shows that we entered the right function.
-      // until we add more functionality here, this is good enough.
-      sandbox.mock(files).expects('getFiles').returns([]);
+      fn(router, {slug: 'example', assetDir: 'example'});
 
-      fn(router, {slug: 'example'});
-
-      sandbox.verify();
+      sinon.assert.calledWith(files.tryRequire, './routes/a');
+      sinon.assert.calledWith(files.tryRequire, './routes/a');
     });
 
     it('throws on bad site', function () {
@@ -124,6 +122,7 @@ describe(_.startCase(filename), function () {
 
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
@@ -143,6 +142,7 @@ describe(_.startCase(filename), function () {
 
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(false);
@@ -166,9 +166,11 @@ describe(_.startCase(filename), function () {
 
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
+      files.tryRequire.returns(_.noop);
       siteService.sites.returns({example: { host: 'example', slug: 'example', assetDir: 'example', dir: 'example' }});
 
       fn(router, {slug: 'example'});

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -192,4 +192,51 @@ describe(_.startCase(filename), function () {
       fn(router, {slug: 'example'});
     });
   });
+
+  describe('addSiteController', function () {
+    const fn = lib[this.title];
+
+    it('does nothing is there is no site directory', function () {
+      const router = {},
+        site = {};
+
+      fn(router, site);
+    });
+
+    it('does nothing if loading site controller fails', function () {
+      const siteDir = 'some-location',
+        router = {},
+        site = {dir: siteDir};
+
+      sandbox.stub(files, 'tryRequire');
+
+      files.tryRequire.returns(false);
+
+      fn(router, site);
+    });
+
+    it('does nothing if site controller is not a function', function () {
+      const siteDir = 'some-location',
+        router = {},
+        site = {dir: siteDir};
+
+      sandbox.stub(files, 'tryRequire');
+
+      files.tryRequire.returns({});
+
+      fn(router, site);
+    });
+
+    it('remembers resolveMedia from controller', function () {
+      const siteDir = 'some-location',
+        router = {},
+        site = {dir: siteDir};
+
+      sandbox.stub(files, 'tryRequire');
+
+      files.tryRequire.returns({});
+
+      fn(router, site);
+    });
+  });
 });

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -56,7 +56,7 @@ function getPageClonePutOperations(pageData, locals) {
       //for all strings that are component references
       promises.push(components.get(pageValue, locals).then(function (refData) {
         //only follow the paths of instance references.  Don't clone default components
-        return composer.resolveDataReferences(refData, isInstanceReferenceObject);
+        return composer.resolveComponentReferences(refData, isInstanceReferenceObject);
       }).then(function (resolvedData) {
         //for each instance reference within resolved data
         _.each(_.listDeepObjects(resolvedData, isInstanceReferenceObject), function (obj) {
@@ -70,7 +70,7 @@ function getPageClonePutOperations(pageData, locals) {
         //put new data using cascading PUT at place that page now points
         return components.getPutOperations(ref, resolvedData, locals);
       }));
-    } else if (typeof pageValue === 'object') {
+    } else {
       //for all object-like things (i.e., objects and arrays)
       promises = promises.concat(getPageClonePutOperations(pageValue, locals));
     }
@@ -134,7 +134,7 @@ function getRecursivePublishedPutOperations(locals) {
      * 4) Get list of put operations needed
      */
     return components.get(rootComponentRef, locals)
-      .then(composer.resolveDataReferences)
+      .then(composer.resolveComponentReferences)
       .then(references.replaceAllVersions(published))
       .then(function (data) {
         return components.getPutOperations(references.replaceVersion(rootComponentRef, published), data, locals);

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -74,7 +74,7 @@ describe(_.startCase(filename), function () {
       components.get.withArgs(layoutUri).returns(bluebird.resolve(layoutReferenceData));
       components.get.withArgs(contentUri).returns(bluebird.resolve(contentData));
       db.batch.returns(bluebird.resolve());
-      db.get.withArgs(innerContentInstanceUri).returns(bluebird.resolve(JSON.stringify(innerContentInstanceData)));
+      components.get.withArgs(innerContentInstanceUri).returns(bluebird.resolve(innerContentInstanceData));
 
       return fn(uri, data).then(function (result) {
         expect(result._ref).to.match(/^domain\.com\/path\/pages\//);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---reporter dot
+--reporter spec
 --ui bdd
 --slow 50
 --timeout 200


### PR DESCRIPTION
New Feature
- Allow sites to modify the media map used within a template.

For example
```js
module.exports = function (router, composer) {

  router.get('/', composer);
  router.get('/:year/:month/:name', composer);

  return router;
};

module.exports.resolveMedia = function (media, locals) {
  const assetPath = locals.site.assetPath;

  if (locals.edit) {
    media.scripts = [assetPath + '/js/edit-before.js'];
  } else {
    media.scripts.unshift(assetPath + '/js/view-before.js');
    media.scripts.push(assetPath + '/js/view-after.js');
  }
};
```