### PR TITLE
page-level-url

### DIFF
--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -33,6 +33,16 @@ function isInstanceReferenceObject(data) {
 }
 
 /**
+ * Get the prefix of a page like 'some-domain.com/some-path/pages/' with the page id.
+ *
+ * @param {string} uri
+ * @returns {string}
+ */
+function getPrefix(uri) {
+  return uri.substr(0, uri.indexOf('/pages/'));
+}
+
+/**
  * Get a reference that is unique, but of the same component type as original.
  * @param {string} uri
  * @returns {string}
@@ -100,7 +110,7 @@ function replacePageReferenceVersions(data, version) {
   var replaceVersion = _.partial(references.replaceVersion, _, version);
 
   return _.mapValues(data, function (value) {
-    if (typeof value === 'string') {
+    if (references.isUri(value)) {
       return replaceVersion(value);
     } else if (_.isArray(value)) {
       return _.map(value, replaceVersion);
@@ -153,13 +163,28 @@ function publish(uri, data, locals) {
   return bluebird.try(function () {
     return data || getLatestData(uri);
   }).then(function (data) {
-    const published = 'published';
+    const published = 'published',
+      prefix = getPrefix(uri),
+      canonicalUrl = data.url,
+      componentList = _.flatten(_.values(_.omit(data, ['layout', 'url'])));
 
-    return bluebird.map(_.flatten(_.values(data)), getRecursivePublishedPutOperations(locals))
+    if (!references.isUrl(canonicalUrl)) {
+      throw new Error('Client: Page must have valid url to publish.');
+    }
+
+    return bluebird.map(componentList, getRecursivePublishedPutOperations(locals))
       .then(_.flatten) // only one level of flattening needed, because getPutOperations should have flattened its list already
       .then(function (ops) {
         // convert the data to all @published
         data = replacePageReferenceVersions(data, published);
+
+        // make public
+        ops.push({
+          type: 'put',
+          key: prefix + '/uris/' + new Buffer(canonicalUrl).toString('base64'),
+          value: uri
+        });
+
         // add page PUT operation last
         return addOp(references.replaceVersion(uri, published), data, ops);
       });

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -107,22 +107,43 @@ describe(_.startCase(filename), function () {
   describe('publish', function () {
     var fn = lib[this.title];
 
-    it('publishes', function () {
+    it('publishes with provided data', function () {
       components.get.returns(bluebird.resolve({}));
       db.batch.returns(bluebird.resolve());
 
-      return fn('domain.com/path/pages/thing', {layout: 'domain.com/path/components/thing'}).then(function (result) {
-        expect(result).to.deep.equal({ layout: 'domain.com/path/components/thing@published' });
+      return fn('domain.com/path/pages/thing', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function (result) {
+        expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
       });
     });
 
-    it('publishes', function () {
+    it('publishes without provided data', function () {
+      components.get.returns(bluebird.resolve({}));
+      db.get.returns(bluebird.resolve(JSON.stringify({layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'})));
+      db.batch.returns(bluebird.resolve());
+
+      return fn('domain.com/path/pages/thing').then(function (result) {
+        expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
+      });
+    });
+
+    it('throws if missing url with provided data', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing', {layout: 'domain.com/path/components/thing'}).then(done).catch(function (error) {
+        expect(error).to.be.an.instanceof(Error);
+        done();
+      });
+    });
+
+    it('throws if missing url without provided data', function (done) {
       components.get.returns(bluebird.resolve({}));
       db.get.returns(bluebird.resolve(JSON.stringify({layout: 'domain.com/path/components/thing'})));
       db.batch.returns(bluebird.resolve());
 
-      return fn('domain.com/path/pages/thing').then(function (result) {
-        expect(result).to.deep.equal({ layout: 'domain.com/path/components/thing@published' });
+      fn('domain.com/path/pages/thing').then(done).catch(function (error) {
+        expect(error).to.be.an.instanceof(Error);
+        done();
       });
     });
   });

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash'),
+  urlParse = require('url'),
   propagatingVersions = ['published', 'latest'];
 
 /**
@@ -56,10 +57,28 @@ function isPropagatingVersion(uri) {
   return !!version && _.contains(propagatingVersions, version);
 }
 
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isUrl(url) {
+  const parts = _.isString(url) && urlParse.parse(url);
 
+  return !!parts && !!parts.protocol && !!parts.hostname && !!parts.path;
+}
+
+/**
+ * @param {string} uri
+ * @returns {boolean}
+ */
+function isUri(uri) {
+  return _.isString(uri) && uri.indexOf(':') === -1;
+}
 
 module.exports.replaceVersion = replaceVersion;
 module.exports.replaceAllVersions = replaceAllVersions;
 module.exports.setPropagatingVersions = setPropagatingVersions;
 module.exports.getPropagatingVersions = getPropagatingVersions;
 module.exports.isPropagatingVersion = isPropagatingVersion;
+module.exports.isUrl = isUrl;
+module.exports.isUri = isUri;

--- a/lib/services/references.test.js
+++ b/lib/services/references.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash'),
+const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
   expect = require('chai').expect,
@@ -18,7 +18,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('replaceVersion', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('replaces version with new version', function () {
       expect(fn('a@b', 'c')).to.equal('a@c');
@@ -34,7 +34,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('replaceAllVersions', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('replaces all versions with new version', function () {
       expect(fn('c')({_ref: 'x@x', deep: {_ref: 'a@b', thing: {_ref: 'a'}}})).to.deep.equal({_ref: 'x@x', deep: {_ref: 'a@c', thing: {_ref: 'a@c'}}});
@@ -46,8 +46,8 @@ describe(_.startCase(filename), function () {
   });
 
   describe('setPropagatingVersions', function () {
-    var fn = lib[this.title],
-      originalValue;
+    const fn = lib[this.title];
+    var originalValue;
 
     before(function () {
       originalValue = lib.getPropagatingVersions();
@@ -59,6 +59,62 @@ describe(_.startCase(filename), function () {
 
     it('sets', function () {
       expect(function () { fn([]); }).to.not.throw();
+    });
+  });
+
+  describe('isUrl', function () {
+    const fn = lib[this.title];
+
+    it('is false when given undefined', function () {
+      expect(fn()).to.equal(false);
+    });
+
+    it('knows a url without path', function () {
+      expect(fn('http://something.com')).to.equal(true);
+    });
+
+    it('knows a url with empty', function () {
+      expect(fn('http://something.com/')).to.equal(true);
+    });
+
+    it('knows a url with port', function () {
+      expect(fn('http://something.com:3333/')).to.equal(true);
+    });
+
+    it('fails without protocol', function () {
+      expect(fn('something.com:3333')).to.equal(false);
+    });
+  });
+
+  describe('isUri', function () {
+    const fn = lib[this.title];
+
+    it('is false when given undefined', function () {
+      expect(fn()).to.equal(false);
+    });
+
+    it('knows not a uri with protocol', function () {
+      expect(fn('http://something.com')).to.equal(false);
+    });
+
+    it('knows not a uri with port', function () {
+      expect(fn('something.com:3333')).to.equal(false);
+    });
+
+    it('knows not a uri with protocol and path', function () {
+      expect(fn('http://something.com/something')).to.equal(false);
+    });
+
+    it('knows not a uri without protocol with path', function () {
+      expect(fn('something.com:3333/something')).to.equal(false);
+    });
+
+    it('knows a uri with path', function () {
+      expect(fn('something.com/something')).to.equal(true);
+    });
+
+    it('knows a uri without path', function () {
+      expect(fn('something.com')).to.equal(true);
     });
   });
 });

--- a/test/api/pages/put.js
+++ b/test/api/pages/put.js
@@ -16,11 +16,13 @@ describe(endpointName, function () {
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
       cascades = apiAccepts.cascades(_.camelCase(filename)),
       pageData = {
+        url: 'http://localhost.example.com',
         layout: 'localhost.example.com/components/layout',
         center: 'localhost.example.com/components/valid',
         side: ['localhost.example.com/components/valid@valid']
       },
       cascadingPageData = {
+        url: 'http://localhost.example.com',
         layout: 'localhost.example.com/components/layoutCascading',
         center: 'localhost.example.com/components/validCascading',
         side: ['localhost.example.com/components/validCascading@valid']
@@ -31,6 +33,7 @@ describe(endpointName, function () {
       cascadingTarget = 'localhost.example.com/components/validDeep',
       versionedPageData = function (version) {
         return {
+          url: 'http://localhost.example.com',
           layout: 'localhost.example.com/components/layout@' + version,
           center: 'localhost.example.com/components/valid@' + version,
           side: ['localhost.example.com/components/valid@' + version]
@@ -41,6 +44,7 @@ describe(endpointName, function () {
       },
       cascadingReturnData = function (version) {
         return {
+          url: 'http://localhost.example.com',
           layout: 'localhost.example.com/components/layoutCascading@' + version,
           center: 'localhost.example.com/components/validCascading@' + version,
           side: ['localhost.example.com/components/validCascading@' + version]
@@ -98,7 +102,6 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid', version: version}, pageData, 200, versionedPageData(version));
       acceptsJsonBody(path, {name: 'valid', version: version}, cascadingPageData, 200, cascadingReturnData(version));
       cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingPageData.center, version), versionedDeepData(version));
-      cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingPageData.layout, version), versionedDeepData(version));
       cascades(path, {name: 'valid', version: version}, cascadingPageData, replaceVersion(cascadingTarget, version), componentData);
 
       // block with _ref at root of object

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -249,7 +249,7 @@ function createsNewVersion(method) {
  * @returns {Function}
  */
 function cascades(method) {
-  return function (path, replacements, data, cascadingTarget, cascadingDeepData) {
+  return function (path, replacements, data, cascadingTarget, cascadingData) {
     var realPath = getRealPath(replacements, path);
 
     it(realPath + ' cascades to ' + cascadingTarget, function () {
@@ -260,9 +260,9 @@ function cascades(method) {
         .set('Host', host)
         .expect(200)
         .then(function () {
-          //expect deep data to now exist
+          //expect cascading data to now exist
           return db.get(cascadingTarget).then(JSON.parse).then(function (result) {
-            expect(result).to.deep.equal(cascadingDeepData);
+            expect(result).to.deep.equal(cascadingData);
           });
         });
     });


### PR DESCRIPTION
New Feature
- `/pages` now have a `url` property that must be a valid url and will not be expanded, cloned or resolved.
- On publish, a `/uris/<new page>` will be created from the url.
- Publishing will 400 if the url is missing.