### PR TITLE
bootstrap-page-url

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -5,6 +5,7 @@ var path = require('path'),
   bluebird = require('bluebird'),
   components = require('./services/components'),
   siteService = require('./services/sites'),
+  references = require('./services/references'),
   db = require('./services/db'),
   log = require('./log'),
   chalk = require('chalk');
@@ -111,7 +112,11 @@ function saveObjects(dbPath, list, save) {
   }));
 }
 
-function applyPrefixToPages(bootstrap, prefix) {
+/**
+ * @param {object} bootstrap
+ * @param {object} site
+ */
+function applyPrefixToPages(bootstrap, site) {
   bootstrap.pages = _.transform(bootstrap.pages, function (obj, value, key) {
     var list = _.listDeepObjects(value);
     list.push(value);
@@ -119,7 +124,11 @@ function applyPrefixToPages(bootstrap, prefix) {
     _.each(list, function (item) {
       _.each(item, function (value, fieldName, obj) {
         if (_.isString(value) && value[0] === '/') {
-          obj[fieldName] = prefix + value;
+          obj[fieldName] = site.prefix + value;
+
+          if (fieldName === 'url') {
+            obj[fieldName] = references.uriToUrl(obj[fieldName], site.proto, site.port);
+          }
         }
       });
     });
@@ -128,11 +137,16 @@ function applyPrefixToPages(bootstrap, prefix) {
   });
 }
 
-function applyPrefixToComponents(bootstrap, prefix) {
+
+/**
+ * @param {object} bootstrap
+ * @param {object} site
+ */
+function applyPrefixToComponents(bootstrap, site) {
   bootstrap.components = _.transform(bootstrap.components, function (obj, value, key) {
     _.each(_.listDeepObjects(value, '_ref'), function (refObj) {
       if (refObj._ref[0] === '/') {
-        refObj._ref = prefix + refObj._ref;
+        refObj._ref = site.prefix + refObj._ref;
       }
     });
 
@@ -140,14 +154,18 @@ function applyPrefixToComponents(bootstrap, prefix) {
   });
 }
 
-function applyPrefixToUris(bootstrap, prefix) {
+/**
+ * @param {object} bootstrap
+ * @param {object} site
+ */
+function applyPrefixToUris(bootstrap, site) {
   bootstrap.uris = _.transform(bootstrap.uris, function (obj, value, key) {
     if (value[0] === '/') {
-      value = prefix + value;
+      value = site.prefix + value;
     }
 
     if (key[0] === '/') {
-      key = prefix + key;
+      key = site.prefix + key;
     }
 
     obj[key] = value;
@@ -158,26 +176,25 @@ function applyPrefixToUris(bootstrap, prefix) {
  * Apply a prefix to all items in the bootstrap file that start with '/'
  *
  * @param {object} bootstrap
- * @param {string} prefix
+ * @param {object} site
  */
-function applyPrefix(bootstrap, prefix) {
-  applyPrefixToUris(bootstrap, prefix);
-  applyPrefixToPages(bootstrap, prefix);
-  applyPrefixToComponents(bootstrap, prefix);
+function applyPrefix(bootstrap, site) {
+  applyPrefixToUris(bootstrap, site);
+  applyPrefixToPages(bootstrap, site);
+  applyPrefixToComponents(bootstrap, site);
 }
 
 /**
  * Load items into db from config object
  * @param {object} data
- * @param {string} [prefix]
+ * @param {object} site
  * @returns {Promise}
  */
-function load(data, prefix) {
-  var promiseComponentsOps, promisePagesOps, promiseUrisOps, promiseListsOps;
+function load(data, site) {
+  var promiseComponentsOps, promisePagesOps, promiseUrisOps, promiseListsOps,
+    prefix = site.prefix;
 
-  if (prefix) {
-    applyPrefix(data, prefix);
-  }
+  applyPrefix(data, site);
 
   promiseListsOps = saveObjects(prefix + '/lists/', data.lists, getPutOperation);
   promiseUrisOps = saveBase64Strings(prefix + '/uris/', data.uris, getPutOperation);
@@ -205,65 +222,47 @@ function load(data, prefix) {
 
 /**
  * Load items into db from yaml file
- * @param {string} path
- * @param {string} [prefix]
+ * @param {string} dir
+ * @param {object} site
  * @returns Promise
  */
-function bootstrapPath(path, prefix) {
-  prefix = prefix || '';
+function bootstrapPath(dir, site) {
   var promise,
-    data = getConfig(path);
+    data = getConfig(dir);
 
   if (data) {
-    promise = load(data, prefix);
+    promise = load(data, site);
   } else {
-    promise = Promise.reject(new Error('No bootstrap found at ' + path));
+    promise = Promise.reject(new Error('No bootstrap found at ' + dir));
   }
 
   return promise;
 }
 
 /**
+ * @param {string} site
  * @returns {Promise}
  */
-function bootstrapCurrentProject() {
-  return bootstrapPath('.').catch(function () {});
-}
-
-/**
- * @param {string} [prefix]
- * @returns {Promise}
- */
-function bootstrapComponents(prefix) {
-  var components = files.getComponents();
+function bootstrapComponents(site) {
+  const components = files.getComponents();
 
   return bluebird.all(_.map(components, function (component) {
-    var componentPath = files.getComponentPath(component);
-    return bootstrapPath(componentPath, prefix).catch(function () {});
-  }));
-}
+    const componentPath = files.getComponentPath(component);
 
-/**
- * @returns {Promise}
- */
-function bootstrapSites() {
-  var sites = siteService.sites();
-
-  return bluebird.all(_.map(sites, function (site) {
-    var prefix = site.path && site.path.length > 1 ? site.host + site.path : site.host;
-
-    return bootstrapComponents(prefix).then(function () {
-      return bootstrapPath(site.dir, prefix).catch(function (ex) {
-        log.error('Bootstrap error:' + ex.stack);
-      });
-    });
+    return bootstrapPath(componentPath, site).catch(function () {});
   }));
 }
 
 module.exports = function () {
-  return bootstrapSites().then(function () {
-    return bootstrapCurrentProject();
-  });
+  const sites = siteService.sites();
+
+  return bluebird.all(_.map(sites, function (site) {
+    return bootstrapComponents(site).then(function () {
+      return bootstrapPath(site.dir, site).catch(function (ex) {
+        log.error('Bootstrap error:' + ex.stack);
+      });
+    });
+  }));
 };
 
 module.exports.bootstrapPath = bootstrapPath;

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -13,10 +13,26 @@ var _ = require('lodash'),
 
 describe(_.startCase(filename), function () {
   var sandbox,
-    bootstrapFake;
+    bootstrapFake,
+    sitesFake;
 
   before(function () {
     this.timeout(400);
+    sitesFake = [{
+      host: 'example1.com',
+      dir: 'example1',
+      prefix: 'example1.com'
+    }, {
+      host: 'example2.com',
+      path: '/',
+      dir: 'example2',
+      prefix: 'example1.com'
+    }, {
+      host: 'example3.com',
+      path: '/some-path',
+      dir: 'example3',
+      prefix: 'example1.com/some-path'
+    }];
     bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap'));
   });
 
@@ -25,6 +41,9 @@ describe(_.startCase(filename), function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(log);
     sandbox.stub(db, 'formatBatchOperations').returns([]);
+    sandbox.stub(siteService);
+
+    siteService.sites.returns(_.cloneDeep(sitesFake));
 
     return db.clear();
   });
@@ -42,7 +61,6 @@ describe(_.startCase(filename), function () {
     var fn = lib;
 
     beforeEach(function () {
-      sandbox.stub(siteService);
       sandbox.stub(path, 'resolve', _.identity);
       sandbox.stub(files, 'isDirectory');
       sandbox.stub(files, 'getYaml');
@@ -51,18 +69,6 @@ describe(_.startCase(filename), function () {
     });
 
     it('', function () {
-      siteService.sites.returns([{
-        host: 'example1.com',
-        dir: 'example1'
-      }, {
-        host: 'example2.com',
-        path: '/',
-        dir: 'example2'
-      }, {
-        host: 'example3.com',
-        path: '/some-path',
-        dir: 'example3'
-      }]);
       files.getComponents.returns(['a', 'b', 'c']);
 
       return fn();
@@ -74,7 +80,7 @@ describe(_.startCase(filename), function () {
 
 
     it('missing bootstrap', function (done) {
-      fn('./jfkdlsa')
+      fn('./jfkdlsa', sitesFake[0])
         .then(done.bind(null, 'should throw'))
         .catch(function () {
           done();
@@ -86,8 +92,8 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config/bootstrap').then(function () {
-        return db.get('/components/image/instances/0')
+      return fn('./test/fixtures/config/bootstrap', sitesFake[0]).then(function () {
+        return db.get(sitesFake[0].prefix + '/components/image/instances/0')
           .then(JSON.parse)
           .then(function (results) {
             expect(results).to.deep.equal({
@@ -103,7 +109,7 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config');
+      return fn('./test/fixtures/config', sitesFake[0]);
     });
 
     it('reads from bootstrap with extension in path', function () {
@@ -111,7 +117,7 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config/bootstrap.yaml');
+      return fn('./test/fixtures/config/bootstrap.yaml', sitesFake[0]);
     });
 
     it('reads uris from bootstrap', function () {
@@ -119,14 +125,14 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return db.pipeToPromise(db.list({prefix: 'test/uris', limit: -1}));
+      return fn('./test/fixtures/config/bootstrap.yaml', sitesFake[0]).then(function () {
+        return db.pipeToPromise(db.list({prefix: sitesFake[0].prefix + '/uris', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.equal({
-          'test/uris/YQ==': 'b',
-          'test/uris/Yw==': 'test/d',
-          'test/uris/dGVzdC9l': 'f',
-          'test/uris/dGVzdC9n': 'test/h'
+          'example1.com/uris/YQ==': 'b',
+          'example1.com/uris/Yw==': 'example1.com/d',
+          'example1.com/uris/ZXhhbXBsZTEuY29tL2U=': 'f',
+          'example1.com/uris/ZXhhbXBsZTEuY29tL2c=': 'example1.com/h'
         });
       });
     });
@@ -136,11 +142,16 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return db.pipeToPromise(db.list({prefix: 'test/pages', limit: -1}));
+      return fn('./test/fixtures/config/bootstrap.yaml', sitesFake[0]).then(function () {
+        return db.pipeToPromise(db.list({prefix: 'example1.com/pages', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.equal({
-          'test/pages/0': '{"layout":"test/a/b","head":"test/c/d"}'
+          'example1.com/pages/0': JSON.stringify({
+            layout: 'example1.com/a/b',
+            url: 'http://example1.com/x/y',
+            body: 'example1.com/c/d',
+            head: ['example1.com/e/f']
+          })
         });
       });
     });
@@ -150,21 +161,21 @@ describe(_.startCase(filename), function () {
       this.slow(50);
       this.timeout(400);
 
-      return fn('./test/fixtures/config/bootstrap.yaml', 'test').then(function () {
-        return db.pipeToPromise(db.list({prefix: 'test/components', limit: -1}));
+      return fn('./test/fixtures/config/bootstrap.yaml', sitesFake[0]).then(function () {
+        return db.pipeToPromise(db.list({prefix: 'example1.com/components', limit: -1}));
       }).then(JSON.parse).then(function (results) {
         expect(results).to.deep.include({
           // instance data of components (prefixes all the way down)
-          'test/components/image/instances/0': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
+          'example1.com/components/image/instances/0': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}',
 
           // note the prefix added
-          'test/components/image/instances/1': '{"_ref":"test/components/image2"}',
+          'example1.com/components/image/instances/1': '{"_ref":"example1.com/components/image2"}',
 
           // note the prefix NOT added
-          'test/components/image/instances/2': '{"_ref":"localhost/components/what"}',
+          'example1.com/components/image/instances/2': '{"_ref":"localhost/components/what"}',
 
           // base data of components
-          'test/components/image2': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}'
+          'example1.com/components/image2': '{"src":"http://placekitten.com/400/600","alt":"adorable kittens"}'
         });
       });
     });

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -75,6 +75,28 @@ function isUri(uri) {
   return _.isString(uri) && uri.indexOf(':') === -1;
 }
 
+/**
+ * Take the protocol and port from a sourceUrl and apply them to some uri
+ * @param {string} uri
+ * @param {string} protocol
+ * @param {string} [port]
+ * @returns {string}
+ */
+function uriToUrl(uri, protocol, port) {
+  // just pretend to start with http; it's overwritten two lines down
+  const parts = urlParse.parse('http://' + uri);
+
+  parts.protocol = protocol || 'http';
+  parts.port = port || process.env.PORT;
+  delete parts.host;
+
+  if (parts.protocol === 'http' && parts.port && parts.port.toString() === '80') {
+    delete parts.port;
+  }
+
+  return parts.format();
+}
+
 module.exports.replaceVersion = replaceVersion;
 module.exports.replaceAllVersions = replaceAllVersions;
 module.exports.setPropagatingVersions = setPropagatingVersions;
@@ -82,3 +104,4 @@ module.exports.getPropagatingVersions = getPropagatingVersions;
 module.exports.isPropagatingVersion = isPropagatingVersion;
 module.exports.isUrl = isUrl;
 module.exports.isUri = isUri;
+module.exports.uriToUrl = uriToUrl;

--- a/lib/services/references.test.js
+++ b/lib/services/references.test.js
@@ -117,4 +117,20 @@ describe(_.startCase(filename), function () {
       expect(fn('something.com')).to.equal(true);
     });
   });
+
+  describe('uriToUrl', function () {
+    const fn = lib[this.title];
+
+    it('converts without protocol and port', function () {
+      expect(fn('localhost')).to.equal('http://localhost/');
+    });
+
+    it('converts given protocol and port', function () {
+      expect(fn('localhost', 'https', '3333')).to.equal('https://localhost:3333/');
+    });
+
+    it('does not say port 80 for http', function () {
+      expect(fn('localhost', 'http', '80')).to.equal('http://localhost/');
+    });
+  });
 });

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -66,6 +66,7 @@ function getSites() {
     siteConfig.dir = dir;
     siteConfig.assetPath = normalizePath(siteConfig.assetPath);
     siteConfig.assetDir = normalizeDirectory(siteConfig.assetDir || 'public');
+    siteConfig.prefix = siteConfig.path && siteConfig.path.length > 1 ? siteConfig.host + siteConfig.path : siteConfig.host;
 
     // check to make sure sites have default properties
     if (!siteConfig.host) {

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -16,6 +16,7 @@ describe(_.startCase(filename), function () {
         slug: 'a',
         host: 'd',
         path: '/e',
+        prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/'
       },
@@ -24,6 +25,27 @@ describe(_.startCase(filename), function () {
         slug: 'b',
         host: 'd',
         path: '/e',
+        prefix: 'd/e',
+        assetDir: 'public',
+        assetPath: '/'
+      }
+    },
+    mockSitesWithoutPaths = {
+      a: {
+        dir: 'z/a',
+        slug: 'a',
+        host: 'd',
+        path: '/',
+        prefix: 'd',
+        assetDir: 'public',
+        assetPath: '/'
+      },
+      b: {
+        dir: 'z/b',
+        slug: 'b',
+        host: 'd',
+        path: '/',
+        prefix: 'd',
         assetDir: 'public',
         assetPath: '/'
       }
@@ -40,6 +62,13 @@ describe(_.startCase(filename), function () {
       slug: 'c',
       host: 'd',
       path: 'e'
+    };
+  }
+
+  function getMockSiteWithoutPath() {
+    return {
+      slug: 'c',
+      host: 'd'
     };
   }
 
@@ -69,6 +98,16 @@ describe(_.startCase(filename), function () {
       files.getYaml.onThirdCall().returns(getMockSite());
 
       expect(fn()).to.deep.equal(mockSites);
+    });
+
+    it('gets prefix for site without path', function () {
+      files.getFolders.returns(['a', 'b']);
+      path.resolve.returns('z');
+      files.getYaml.onFirstCall().returns(getMockSiteWithoutPath());
+      files.getYaml.onSecondCall().returns(getMockSiteWithoutPath());
+      files.getYaml.onThirdCall().returns(getMockSiteWithoutPath());
+
+      expect(fn()).to.deep.equal(mockSitesWithoutPaths);
     });
 
     it('throw error on missing host', function () {

--- a/test/fixtures/config/bootstrap.yaml
+++ b/test/fixtures/config/bootstrap.yaml
@@ -18,7 +18,10 @@ components:
 pages:
   -
     layout: /a/b
-    head: /c/d
+    url: /x/y
+    body: /c/d
+    head:
+      - /e/f
 uris:
   a: b
   c: /d

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---reporter spec
+--reporter dot
 --ui bdd
 --slow 50
 --timeout 200


### PR DESCRIPTION
Patch
- Bootstrap will treat `url` in a page as a canonical url

Note:  We will need to say the port in config.yaml or local.yaml now for this to work.  :/