### PR TITLE
don't rely on global modules

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,12 +3,6 @@ machine:
     America/New_York
   node:
     version: 4.0
-dependencies:
-  pre:
-    - npm install -g istanbul
-    - npm install -g node-gyp
-    - npm install -g jscs
-    - npm install -g jshint
 test:
   post:
     - cp -r ./coverage/* $CIRCLE_ARTIFACTS

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "chai": "^2.1",
     "coveralls": "^2.11.2",
-    "istanbul": "^0.4.1",
-    "jscs": "^2.6.0",
-    "jshint": "^2.8.0",
+    "istanbul": "^0.4",
+    "jscs": "^2.6",
+    "jshint": "^2.8",
     "mocha": "^2.2",
     "mock-fs": "^2.5.0",
     "sinon": "^1.14",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An API mixin for Express that saves, publishes and composes data with the key-value store of your choice.",
   "main": "index.js",
   "scripts": {
-    "test": "jscs . && jshint lib test && istanbul cover node_modules/.bin/_mocha"
+    "test": "node_modules/.bin/jscs . && node_modules/.bin/jshint lib test && node_modules/.bin/istanbul cover node_modules/.bin/_mocha"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,9 @@
   "devDependencies": {
     "chai": "^2.1",
     "coveralls": "^2.11.2",
+    "istanbul": "^0.4.1",
+    "jscs": "^2.6.0",
+    "jshint": "^2.8.0",
     "mocha": "^2.2",
     "mock-fs": "^2.5.0",
     "sinon": "^1.14",


### PR DESCRIPTION
* added `jscs`, `jshint`, and `istanbul` to `devDependencies`
* `npm test` references them rather than global versions