### PR TITLE
catch-empty-page-data

### DIFF
--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -159,6 +159,7 @@ function getSite(prefix, locals) {
 
 /**
  * Cannot contain any empty value (null, '', undefined, false)
+ * @param {object} data
  * @throws
  */
 function assertNoEmptyValues(data) {

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -158,6 +158,20 @@ function getSite(prefix, locals) {
 }
 
 /**
+ * Cannot contain any empty value (null, '', undefined, false)
+ * @throws
+ */
+function assertNoEmptyValues(data) {
+  _.each(data, function (value) {
+    if (!value) {
+      throw new Error('Client: page cannot have empty values');
+    }
+  });
+
+  _.each(_.listDeepObjects(data), assertNoEmptyValues);
+}
+
+/**
  * Publish a uri
  * @param {string} uri
  * @param {object} [data]
@@ -169,6 +183,10 @@ function publish(uri, data, locals) {
     site = getSite(prefix, locals);
 
   return bluebird.try(function () {
+    if (data) {
+      assertNoEmptyValues(data);
+    }
+
     return data || getLatestData(uri);
   }).then(function (pageData) {
     const published = 'published',

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -144,6 +144,19 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('throws on empty data', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com', head: ['']})
+        .then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: page cannot have empty values');
+          done();
+        });
+    });
+
     it('publishes with provided data', function () {
       components.get.returns(bluebird.resolve({}));
       db.batch.returns(bluebird.resolve());


### PR DESCRIPTION
Patch
- catch when someone tries to publish a page with empty data