### PR TITLE
report memory leaks

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
+var memoryLeakThreshold = 1000;
+const _ = require('lodash'),
+  log = require('./log'),
+  minute = 60000;
 
 /**
  * @param {*} obj
@@ -42,5 +45,74 @@ function setDeepObjectTypesReadOnly(obj) {
   });
 }
 
+function defineReadOnly(definition) {
+  if (!definition.get) {
+    definition.writable = false;
+  }
+  definition.enumerable = false;
+  definition.configurable = false;
+  delete definition.set;
+  return definition;
+}
+
+function defineWritable(definition) {
+  if (!definition.set && !definition.get) {
+    definition.writable = true;
+  }
+  definition.enumerable = false;
+  definition.configurable = false;
+  return definition;
+}
+
+/**
+ * Report that a memory leak occurred
+ * @param {function} fn
+ * @param {object} cache
+ */
+function reportMemoryLeak(fn, cache) {
+  log.warn('Memory leak', fn.name, cache);
+}
+
+/**
+ * Memoize, but warn if the target is not suitable for memoization
+ * @param {function} fn
+ * @returns {function}
+ */
+function memoize(fn) {
+  const dataProp = '__data__',
+    memFn = _.memoize.apply(_, _.slice(arguments)),
+    report = _.throttle(reportMemoryLeak, minute),
+    controlFn = function () {
+      const result = memFn.apply(null,  _.slice(arguments));
+
+      if (_.size(memFn.cache[dataProp]) >= memoryLeakThreshold) {
+        report(fn, memFn.cache[dataProp]);
+      }
+
+      return result;
+    };
+
+  Object.defineProperty(controlFn, 'cache', defineWritable({
+    get() { return memFn.cache; },
+    set(value) { memFn.cache = value; }
+  }));
+
+  return controlFn;
+}
+
+function setMemoryLeakThreshold(value) {
+  memoryLeakThreshold = value;
+}
+
+function getMemoryLeakThreshold() {
+  return memoryLeakThreshold;
+}
+
 module.exports.setReadOnly = setReadOnly;
 module.exports.setDeepObjectTypesReadOnly = setDeepObjectTypesReadOnly;
+module.exports.defineReadOnly = defineReadOnly;
+module.exports.defineWritable = defineWritable;
+module.exports.memoize = memoize;
+
+module.exports.setMemoryLeakThreshold = setMemoryLeakThreshold;
+module.exports.getMemoryLeakThreshold = getMemoryLeakThreshold;

--- a/lib/control.test.js
+++ b/lib/control.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var _ = require('lodash'),
+const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
+  log = require('./log'),
   expect = require('chai').expect,
   sinon = require('sinon');
 
@@ -11,6 +12,7 @@ describe(_.startCase(filename), function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(log);
   });
 
   afterEach(function () {
@@ -18,7 +20,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('setReadOnly', function () {
-    var fn = lib[this.title];
+    const fn = lib[this.title];
 
     it('takes null', function () {
       var data = null;
@@ -30,6 +32,85 @@ describe(_.startCase(filename), function () {
       var data = {};
 
       expect(fn(data)).to.equal(data);
+    });
+  });
+
+  describe('memoize', function () {
+    var memLeak;
+    const fn = lib[this.title];
+
+    beforeEach(function () {
+      memLeak = lib.getMemoryLeakThreshold();
+    });
+
+    afterEach(function () {
+      lib.setMemoryLeakThreshold(memLeak);
+    });
+
+    it('memoizes', function () {
+      var resultFn, target = function () { return 'd'; };
+
+      resultFn = fn(target);
+
+      resultFn('a', 'b', 'c');
+
+      expect(resultFn.cache.__data__).to.deep.equal({a: 'd'});
+    });
+
+    it('warns when over the limit', function () {
+      var resultFn, target = function namedFn() { return 'd'; };
+
+      lib.setMemoryLeakThreshold(2);
+
+      resultFn = fn(target);
+
+      resultFn('a');
+      resultFn('b');
+      resultFn('c');
+
+      sinon.assert.calledWith(log.warn, 'Memory leak', 'namedFn', { a: 'd', b: 'd', c: 'd' });
+    });
+  });
+
+  describe('defineReadOnly', function () {
+    const fn = lib[this.title];
+
+    it('defines a property that is read-only', function () {
+      expect(fn({})).to.deep.equal({ writable: false, enumerable: false, configurable: false});
+    });
+
+    it('defines a property that is read-only with a getter', function () {
+      const getter = _.noop;
+
+      expect(fn({get: getter})).to.deep.equal({ enumerable: false, configurable: false, get: getter});
+    });
+
+    it('defines a property that is read-only with a getter and setter, but only the getter works', function () {
+      const getter = _.noop,
+        setter = _.noop;
+
+      expect(fn({get: getter, set: setter})).to.deep.equal({ enumerable: false, configurable: false, get: getter});
+    });
+  });
+
+  describe('defineWritable', function () {
+    const fn = lib[this.title];
+
+    it('defines a property that is writable', function () {
+      expect(fn({})).to.deep.equal({writable: true, enumerable: false, configurable: false});
+    });
+
+    it('defines a property that is writable with a getter', function () {
+      const getter = _.noop;
+
+      expect(fn({get: getter})).to.deep.equal({enumerable: false, configurable: false, get: getter});
+    });
+
+    it('defines a property that is writable with a getter and setter', function () {
+      const getter = _.noop,
+        setter = _.noop;
+
+      expect(fn({get: getter, set: setter})).to.deep.equal({enumerable: false, configurable: false, get: getter, set: setter});
     });
   });
 });

--- a/lib/files.js
+++ b/lib/files.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var _ = require('lodash'),
+  control = require('./control'),
   fs = require('fs'),
   path = require('path'),
   yaml = require('js-yaml'),
@@ -251,16 +252,16 @@ function getComponentPackage(name) {
   return componentPath && tryRequireEach([componentPath + '/package.json']);
 }
 
-exports.getYaml = _.memoize(getYaml);
-exports.getFiles = _.memoize(getFiles);
-exports.getFolders = _.memoize(getFolders);
-exports.fileExists = _.memoize(fileExists);
-exports.getComponents = _.memoize(getComponents);
-exports.getComponentPath = _.memoize(getComponentPath);
-exports.getComponentModule = _.memoize(getComponentModule);
-exports.getComponentPackage = _.memoize(getComponentPackage);
-exports.isDirectory = _.memoize(isDirectory);
-exports.tryRequire = _.memoize(tryRequire);
+exports.getYaml = control.memoize(getYaml);
+exports.getFiles = control.memoize(getFiles);
+exports.getFolders = control.memoize(getFolders);
+exports.fileExists = control.memoize(fileExists);
+exports.getComponents = control.memoize(getComponents);
+exports.getComponentPath = control.memoize(getComponentPath);
+exports.getComponentModule = control.memoize(getComponentModule);
+exports.getComponentPackage = control.memoize(getComponentPackage);
+exports.isDirectory = control.memoize(isDirectory);
+exports.tryRequire = control.memoize(tryRequire);
 
 // for testing
 exports.setPackageConfiguration = setPackageConfiguration;

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -348,7 +348,7 @@ function getTemplate(name, templateName) {
   }
 
   // return the first template found
-  return getPossibleTemplates(name, templateName)[0];
+  return module.exports.getPossibleTemplates(name, templateName)[0];
 }
 
 /**
@@ -429,11 +429,12 @@ module.exports.putTag = putTag;
 module.exports.putDefaultBehavior = putDefaultBehavior;
 
 // repeatable look-ups
-module.exports.getTemplate = _.memoize(getTemplate, joinArguments);
-module.exports.getName = _.memoize(getName);
-module.exports.getSchema = _.memoize(getSchema);
-module.exports.getScripts = _.memoize(getScripts, joinArguments);
-module.exports.getStyles = _.memoize(getStyles, joinArguments);
+module.exports.getName = getName; //too large to memoize
+module.exports.getTemplate = getTemplate; //too large to memoize
+module.exports.getPossibleTemplates = control.memoize(getPossibleTemplates, joinArguments);
+module.exports.getSchema = control.memoize(getSchema);
+module.exports.getScripts = control.memoize(getScripts, joinArguments);
+module.exports.getStyles = control.memoize(getStyles, joinArguments);
 
 // data rearrangement
 module.exports.getIndices = getIndices;

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -31,9 +31,8 @@ describe(_.startCase(filename), function () {
     sandbox.stub(files);
     sandbox.stub(log);
 
-    lib.getName.cache = new _.memoize.Cache();
+    lib.getPossibleTemplates.cache = new _.memoize.Cache();
     lib.getSchema.cache = new _.memoize.Cache();
-    lib.getTemplate.cache = new _.memoize.Cache();
     lib.getScripts.cache = new _.memoize.Cache();
     lib.getStyles.cache = new _.memoize.Cache();
   });

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -1,5 +1,6 @@
 'use strict';
 var _ = require('lodash'),
+  control = require('../control'),
   files = require('../files'),
   path = require('path');
 
@@ -104,7 +105,7 @@ function getSiteFromPrefix(prefix) {
   return getSite(split[0], '/' + split[1]);
 }
 
-module.exports.sites = _.memoize(getSites);
+module.exports.sites = control.memoize(getSites);
 module.exports.get = getSite;
 module.exports.getSite = getSite;
 module.exports.getSiteFromPrefix = getSiteFromPrefix;

--- a/test/fixtures/mocks/req.js
+++ b/test/fixtures/mocks/req.js
@@ -1,25 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
-
-function defineReadOnly(definition) {
-  if (!definition.get) {
-    definition.writable = false;
-  }
-  definition.enumerable = false;
-  definition.configurable = false;
-  delete definition.set;
-  return definition;
-}
-
-function defineWritable(definition) {
-  if (!definition.set && !definition.get) {
-    definition.writable = true;
-  }
-  definition.enumerable = false;
-  definition.configurable = false;
-  return definition;
-}
+var _ = require('lodash'),
+  control = require('../../../lib/control');
 
 /**
  *
@@ -38,7 +20,7 @@ module.exports = function () {
     headers = {},
     req = {};
 
-  Object.defineProperty(req, 'url', defineReadOnly({
+  Object.defineProperty(req, 'url', control.defineReadOnly({
     get: function () {
       var result = path;
 
@@ -50,15 +32,15 @@ module.exports = function () {
     }
   }));
 
-  Object.defineProperty(req, 'uri', defineReadOnly({
+  Object.defineProperty(req, 'uri', control.defineReadOnly({
     get: function () { return hostname + baseUrl + path; }
   }));
 
-  Object.defineProperty(req, 'vhost', defineReadOnly({
+  Object.defineProperty(req, 'vhost', control.defineReadOnly({
     get: function () { return {hostname: hostname}; }
   }));
 
-  Object.defineProperty(req, 'originalUrl', defineReadOnly({
+  Object.defineProperty(req, 'originalUrl', control.defineReadOnly({
     get: function () {
       var result = baseUrl + path;
 
@@ -70,32 +52,32 @@ module.exports = function () {
     }
   }));
 
-  Object.defineProperty(req, 'query', defineWritable({
+  Object.defineProperty(req, 'query', control.defineWritable({
     get: function () { return query; },
     set: function (value) { query = value; }
   }));
 
-  Object.defineProperty(req, 'path', defineWritable({
+  Object.defineProperty(req, 'path', control.defineWritable({
     get: function () { return path; },
     set: function (value) { path = value; }
   }));
 
-  Object.defineProperty(req, 'baseUrl', defineWritable({
+  Object.defineProperty(req, 'baseUrl', control.defineWritable({
     get: function () { return baseUrl; },
     set: function (value) { baseUrl = value; }
   }));
 
-  Object.defineProperty(req, 'hostname', defineWritable({
+  Object.defineProperty(req, 'hostname', control.defineWritable({
     get: function () { return hostname; },
     set: function (value) { hostname = value; }
   }));
 
-  Object.defineProperty(req, 'params', defineWritable({
+  Object.defineProperty(req, 'params', control.defineWritable({
     get: function () { return params; },
     set: function (value) { params = value; }
   }));
 
-  Object.defineProperty(req, 'headers', defineWritable({
+  Object.defineProperty(req, 'headers', control.defineWritable({
     get: function () { return headers; },
     set: function (value) { headers = value; }
   }));


### PR DESCRIPTION
Patch
- if any `_.memoize` function goes above 1000 internal items, log a warning a maximum of once a minute about the memory leak.

@chrismika @yoshokatana @gloddy @cruzanmo 