### PR TITLE
better media adding when dealing with inline scripts / styles

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -27,11 +27,17 @@ function wrapComments(list, name) {
  * @returns {number}
  */
 function findBottom(str) {
-  var index = str.lastIndexOf('</body>');
-  if (index === -1) {
-    index = str.lastIndexOf('</');
+  var body = str.lastIndexOf('</body>'),
+    script = str.indexOf('<script>'),
+    closeTag = str.lastIndexOf('</');
+
+  if (body > -1) {
+    return body; // right before body closes
+  } else if (script > -1) {
+    return script; // right before FIRST inline script
+  } else {
+    return closeTag; // right before last tag closes
   }
-  return index;
 }
 
 /**
@@ -39,11 +45,17 @@ function findBottom(str) {
  * @returns {number}
  */
 function findTop(str) {
-  var index = str.indexOf('</head>');
-  if (index === -1) {
-    index = str.indexOf('>') + 1;
+  var head = str.indexOf('</head>'), // right before head closes
+    style = str.indexOf('<style>'), // right before inline styles
+    closeTag = str.indexOf('>'); // right after first tag
+
+  if (head > -1) {
+    return head;
+  } else if (style > -1) {
+    return style;
+  } else {
+    return closeTag + 1;
   }
-  return index;
 }
 
 /**

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -11,10 +11,14 @@ describe(_.startCase(filename), function () {
   var sandbox,
     basicHtml = '<html><head></head><body></body></html>',
     basicSection = '<section><header></header><footer></footer></section>',
+    componentWithInlineStyles = '<style></style><div></div>',
+    componentWithInlineScripts = '<div></div><script></script>',
     componentStyleHtml = '<html><head>\n<!-- Stylesheets Begin -->\n<link rel="stylesheet" type="text/css" href="a" />\n<!-- Stylesheets End -->\n</head><body></body></html>',
     componentStyleSection = '<section>\n<!-- Stylesheets Begin -->\n<link rel="stylesheet" type="text/css" href="a" />\n<!-- Stylesheets End -->\n<header></header><footer></footer></section>',
+    componentWithInlineStylesHtml = '\n<!-- Stylesheets Begin -->\n<link rel="stylesheet" type="text/css" href="a" />\n<!-- Stylesheets End -->\n<style></style><div></div>',
     componentScriptHtml = '<html><head></head><body>\n<!-- Scripts Begin -->\n<script type="text/javascript" src="a"></script>\n<!-- Scripts End -->\n</body></html>',
-    componentScriptSection = '<section><header></header><footer></footer>\n<!-- Scripts Begin -->\n<script type="text/javascript" src="a"></script>\n<!-- Scripts End -->\n</section>';
+    componentScriptSection = '<section><header></header><footer></footer>\n<!-- Scripts Begin -->\n<script type="text/javascript" src="a"></script>\n<!-- Scripts End -->\n</section>',
+    componentWithInlineScriptsHtml = '<div></div>\n<!-- Scripts Begin -->\n<script type="text/javascript" src="a"></script>\n<!-- Scripts End -->\n<script></script>';
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
@@ -85,6 +89,18 @@ describe(_.startCase(filename), function () {
       components.getScripts.onCall(0).returns(['/js/a.js']);
 
       expect(fn(mediaMap({scripts:['a'], styles: []}))(basicSection)).to.deep.equal(componentScriptSection);
+    });
+
+    it('adds to top after inline styles', function () {
+      components.getStyles.onCall(0).returns(['/css/a.css']);
+
+      expect(fn(mediaMap({scripts:[], styles: ['a']}))(componentWithInlineStyles)).to.deep.equal(componentWithInlineStylesHtml);
+    });
+
+    it('adds to bottom before inline scripts', function () {
+      components.getScripts.onCall(0).returns(['/js/a.js']);
+
+      expect(fn(mediaMap({scripts:['a'], styles: []}))(componentWithInlineScripts)).to.deep.equal(componentWithInlineScriptsHtml);
     });
   });
 


### PR DESCRIPTION
This adjusts the `media` module's `findTop` and `findBottom` functions to better handle cases where components have inline `<script>` and `<style>` tags. The logic remains the same for all other situations.

* `findTop` (used to add `<link rel="stylesheet">`) will return the index right before the first inline style tag, if it exists
* `findBottom` (used to add `<script src>`) will return the index right before the first inline script tag, if it exists