### PR TITLE
use X-Forwarded-Host for locals.url if exists

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -28,7 +28,7 @@ const _ = require('lodash'),
  */
 function addSiteLocals(site) {
   return function (req, res, next) {
-    res.locals.url = req.protocol + '://' + req.get('host') + req.originalUrl;
+    res.locals.url = req.protocol + '://' + req.hostname + req.originalUrl;
     res.locals.site = site;
 
     next();


### PR DESCRIPTION
Patch
- `locals.url` was not respecting X-Forwarded-Host.  Now it does.