### PR TITLE
block uris with quotes in them

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -118,12 +118,26 @@ function sendJSONErrorCode(code, message, res, extras) {
  * @param {number} code
  * @param {string} message
  * @param res
+ * @returns {function}
+ */
+function sendTextErrorCode(code, message, res) {
+  return function () {
+    res.type('text');
+    res.send(code + ' ' + message);
+  };
+}
+
+/**
+ * @param {number} code
+ * @param {string} message
+ * @param res
  * @param {object} extras
  */
 function sendDefaultResponseForCode(code, message, res, extras) {
   res.status(code).format({
     json: sendJSONErrorCode(code, message, res, extras),
     html: sendHTMLErrorCode(code, message, res),
+    text: sendTextErrorCode(code, message, res),
     default: sendDefaultErrorCode(code, res)
   });
 }

--- a/lib/services/uris.js
+++ b/lib/services/uris.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const db = require('./db'),
+const _ = require('lodash'),
+  db = require('./db'),
   references = require('./references'),
   notifications = require('./notifications'),
   siteService = require('./sites');
@@ -21,6 +22,10 @@ function get(uri) {
 function put(uri, body) {
   if (uri === body) {
     throw new Error('Client: Cannot point uri at itself');
+  }
+
+  if (_.contains(body, '"') || _.contains(body, '\'')) {
+    throw new Error('Client: Destination cannot contain quotes');
   }
 
   if (references.isPropagatingVersion(body)) {

--- a/test/api/uris/delete.js
+++ b/test/api/uris/delete.js
@@ -35,7 +35,7 @@ describe(endpointName, function () {
       acceptsJson(path, {}, 405, { allow:['get'], code: 405, message: 'Method DELETE not allowed' });
       acceptsJsonBody(path, {}, {}, 405, { allow:['get'], code: 405, message: 'Method DELETE not allowed' });
       acceptsHtml(path, {}, 405, '405 Method DELETE not allowed');
-      acceptsText(path, {}, 405, 'Method Not Allowed');
+      acceptsText(path, {}, 405, '405 Method DELETE not allowed');
     });
 
     describe('/uris/:name', function () {
@@ -54,10 +54,10 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
 
       acceptsText(path, {name: 'valid'}, 200, data);
-      acceptsText(path, {name: 'missing'}, 404, 'Not Found');
+      acceptsText(path, {name: 'missing'}, 404, '404 Not Found');
 
       acceptsTextBody(path, {name: 'valid'}, data, 200, data);
-      acceptsTextBody(path, {name: 'missing'}, data, 404, 'Not Found');
+      acceptsTextBody(path, {name: 'missing'}, data, 404, '404 Not Found');
     });
   });
 });

--- a/test/api/uris/get.js
+++ b/test/api/uris/get.js
@@ -32,7 +32,7 @@ describe(endpointName, function () {
 
       acceptsJson(path, {}, 200, '["localhost.example.com/uris/valid"]');
       acceptsHtml(path, {}, 406, '406 text/html not acceptable');
-      acceptsText(path, {}, 406, 'Not Acceptable');
+      acceptsText(path, {}, 406, '406 text/plain not acceptable');
     });
 
     describe('/uris/:name', function () {
@@ -50,9 +50,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
 
-      acceptsText(path, {name: 'invalid'}, 404, 'Not Found');
+      acceptsText(path, {name: 'invalid'}, 404, '404 Not Found');
       acceptsText(path, {name: 'valid'}, 200, data);
-      acceptsText(path, {name: 'missing'}, 404, 'Not Found');
+      acceptsText(path, {name: 'missing'}, 404, '404 Not Found');
     });
   });
 });

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -35,7 +35,7 @@ describe(endpointName, function () {
       acceptsJson(path, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
       acceptsJsonBody(path, {}, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
       acceptsHtml(path, {}, 405, '405 Method PUT not allowed');
-      acceptsText(path, {}, 405, 'Method Not Allowed');
+      acceptsText(path, {}, 405, '405 Method PUT not allowed');
     });
 
     describe('/uris/:name', function () {
@@ -57,10 +57,12 @@ describe(endpointName, function () {
       acceptsTextBody(path, {name: 'valid'}, data, 200, data);
       acceptsTextBody(path, {name: 'missing'}, data, 200, data);
       // propagating versions shouldn't be here. Only published things can be public, so all uris are assumed to be @published already
-      acceptsTextBody(path, {name: 'valid'}, 'domain/pages/test@published', 400, 'Bad Request');
+      acceptsTextBody(path, {name: 'valid'}, 'domain/pages/test@published', 400, '400 Cannot point uri at propagating version, such as @published');
 
       // deny uris pointing to themselves
-      acceptsTextBody(path, {name: 'valid'}, 'localhost.example.com/uris/valid', 400);
+      acceptsTextBody(path, {name: 'valid'}, 'localhost.example.com/uris/valid', 400, '400 Cannot point uri at itself');
+      // deny uris with quotes
+      acceptsTextBody(path, {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Destination cannot contain quotes');
     });
   });
 });


### PR DESCRIPTION
Patch
- Return errors from `plain/text` endpoints with client error messages intact on 400s.
- Block URIs with quotes