### PR TITLE
adds parsing of environment variables in yaml files

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -14,6 +14,7 @@ var _ = require('lodash'),
   path = require('path'),
   yaml = require('js-yaml'),
   pkg = require(path.resolve('package.json')),
+  temp2env = require('template2env'),
   req = require;
 
 /**
@@ -209,6 +210,15 @@ function getYaml(filename) {
 }
 
 /**
+ * @param {string} filename
+ * @return {string}
+ */
+function getYamlWithEnv(filename) {
+  let yamlParsed = temp2env(readFile(filename + '.yaml') || readFile(filename + '.yml'));
+  return yaml.safeLoad(yamlParsed);
+}
+
+/**
  * @param {object} value
  */
 function setPackageConfiguration(value) {
@@ -253,6 +263,7 @@ function getComponentPackage(name) {
 }
 
 exports.getYaml = control.memoize(getYaml);
+exports.getYamlWithEnv = control.memoize(getYamlWithEnv);
 exports.getFiles = control.memoize(getFiles);
 exports.getFolders = control.memoize(getFolders);
 exports.fileExists = control.memoize(fileExists);

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -8,7 +8,8 @@ var _ = require('lodash'),
   yaml = require('js-yaml'),
   glob = require('glob'),
   lib = require('./' + filename),
-  pkg = require('../test/fixtures/config/package.json');
+  pkg = require('../test/fixtures/config/package.json'),
+  temp2env = require('template2env');
 
 describe(_.startCase(filename), function () {
   var req, sandbox;
@@ -164,11 +165,50 @@ describe(_.startCase(filename), function () {
 
     it('returns result', function () {
       var filename = 'some-name',
+        result = 'some result',
+        expected = 'some result';
+
+      yaml.safeLoad.returns(temp2env(result));
+
+      expect(fn(filename)).to.equal(expected);
+    });
+
+    it('returns result from first file', function () {
+      var filename = 'some-name',
         result = 'some result';
 
-      yaml.safeLoad.returns(result);
+      fs.readFileSync.onCall(0).returns(result);
+      fs.readFileSync.onCall(1).throws();
+      yaml.safeLoad.returnsArg(0);
 
       expect(fn(filename)).to.equal(result);
+    });
+
+    it('returns result from second file', function () {
+      var filename = 'some-name',
+        result = 'some result';
+
+      fs.readFileSync.onCall(0).throws();
+      fs.readFileSync.onCall(1).returns(result);
+      yaml.safeLoad.returnsArg(0);
+
+      expect(fn(filename)).to.equal(result);
+    });
+  });
+
+  describe('getYamlWithEnv', function () {
+    var fn = lib[this.title];
+
+    it('returns result', function () {
+      var filename = 'some-name',
+        result = 'some ${FOO}',
+        expected = 'some result';
+
+      process.env.FOO = 'result';
+
+      yaml.safeLoad.returns(temp2env(result));
+
+      expect(fn(filename)).to.equal(expected);
     });
 
     it('returns result from first file', function () {

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -53,8 +53,8 @@ function getSites() {
 
   files.getFolders(instanceSitesFolder).forEach(function (site) {
     var dir = path.join(instanceSitesFolder, site),
-      siteConfig = files.getYaml(path.join(dir, 'config')),
-      localConfig = files.getYaml(path.join(dir, 'local'));
+      siteConfig = files.getYamlWithEnv(path.join(dir, 'config')),
+      localConfig = files.getYamlWithEnv(path.join(dir, 'local'));
 
     //apply locals over site config
     if (localConfig) {

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -77,7 +77,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(fs, 'readFileSync');
     sandbox.stub(path, 'resolve');
     sandbox.stub(files, 'getFolders');
-    sandbox.stub(files, 'getYaml');
+    sandbox.stub(files, 'getYamlWithEnv');
 
     // clear the caches
     lib.sites.cache = new _.memoize.Cache();
@@ -93,9 +93,9 @@ describe(_.startCase(filename), function () {
     it('gets', function () {
       files.getFolders.returns(['a', 'b']);
       path.resolve.returns('z');
-      files.getYaml.onFirstCall().returns(getMockSite());
-      files.getYaml.onSecondCall().returns(getMockSite());
-      files.getYaml.onThirdCall().returns(getMockSite());
+      files.getYamlWithEnv.onFirstCall().returns(getMockSite());
+      files.getYamlWithEnv.onSecondCall().returns(getMockSite());
+      files.getYamlWithEnv.onThirdCall().returns(getMockSite());
 
       expect(fn()).to.deep.equal(mockSites);
     });
@@ -103,9 +103,9 @@ describe(_.startCase(filename), function () {
     it('gets prefix for site without path', function () {
       files.getFolders.returns(['a', 'b']);
       path.resolve.returns('z');
-      files.getYaml.onFirstCall().returns(getMockSiteWithoutPath());
-      files.getYaml.onSecondCall().returns(getMockSiteWithoutPath());
-      files.getYaml.onThirdCall().returns(getMockSiteWithoutPath());
+      files.getYamlWithEnv.onFirstCall().returns(getMockSiteWithoutPath());
+      files.getYamlWithEnv.onSecondCall().returns(getMockSiteWithoutPath());
+      files.getYamlWithEnv.onThirdCall().returns(getMockSiteWithoutPath());
 
       expect(fn()).to.deep.equal(mockSitesWithoutPaths);
     });
@@ -113,8 +113,8 @@ describe(_.startCase(filename), function () {
     it('throw error on missing host', function () {
       files.getFolders.returns(['a', 'b']);
       path.resolve.returns('z');
-      files.getYaml.onFirstCall().returns(getMockBadSite());
-      files.getYaml.onSecondCall().returns(getMockBadSite());
+      files.getYamlWithEnv.onFirstCall().returns(getMockBadSite());
+      files.getYamlWithEnv.onSecondCall().returns(getMockBadSite());
 
       expect(function () { fn(); }).to.throw();
     });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "memdown": "^1.0.0",
     "multiplex-templates": "^1.2",
     "node-fetch": "^1.3",
+    "template2env": "^1.0.1",
     "through2-filter": "^2.0",
     "vhost": "^3.0.0",
     "winston": "^2.1"


### PR DESCRIPTION
adds a function to the files service for parsing yaml files using [template2env](https://github.com/ughitsaaron/template2env). this allows us to include environment variables in clay config files--making configuring clay for different environments (e.g., dev, staging, qa, and prod) much simpler.