### PR TITLE
#getYaml checks filename & runs temp2env on "config" & "local"

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -14,7 +14,9 @@ var _ = require('lodash'),
   path = require('path'),
   yaml = require('js-yaml'),
   pkg = require(path.resolve('package.json')),
-  req = require;
+  temp2env = require('template2env'),
+  req = require,
+  allowedEnvFiles = ['local', 'config'];
 
 /**
  * @param {string} filename
@@ -201,11 +203,34 @@ function tryRequireEach(paths) {
 }
 
 /**
+ * @param {Array} value
+ */
+function setAllowedEnvFiles(value) {
+  allowedEnvFiles = value;
+}
+
+/**
+ * @return {Array}
+ */
+function getAllowedEnvFiles() {
+  return allowedEnvFiles;
+}
+
+/**
  * @param {string} filename
  * @returns {string}
  */
 function getYaml(filename) {
-  return yaml.safeLoad(readFile(filename + '.yaml') || readFile(filename + '.yml'));
+  const data = readFile(filename + '.yaml') || readFile(filename + '.yml'),
+    basename = path.basename(filename, path.extname(filename));
+
+  if (_.contains(allowedEnvFiles, basename)) {
+    // if filename is a config or local file
+    // parse yaml for env variables
+    return yaml.safeLoad(temp2env.interpolate(data));
+  } else {
+    return yaml.safeLoad(data);
+  }
 }
 
 /**
@@ -266,3 +291,5 @@ exports.tryRequire = control.memoize(tryRequire);
 // for testing
 exports.setPackageConfiguration = setPackageConfiguration;
 exports.setRequire = setRequire;
+exports.setAllowedEnvFiles = setAllowedEnvFiles;
+exports.getAllowedEnvFiles = getAllowedEnvFiles;

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   expect = require('chai').expect,
@@ -8,7 +9,8 @@ var _ = require('lodash'),
   yaml = require('js-yaml'),
   glob = require('glob'),
   lib = require('./' + filename),
-  pkg = require('../test/fixtures/config/package.json');
+  pkg = require('../test/fixtures/config/package.json'),
+  temp2env = require('template2env');
 
 describe(_.startCase(filename), function () {
   var req, sandbox;
@@ -28,6 +30,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(path, 'resolve');
     sandbox.stub(yaml);
     sandbox.stub(glob, 'sync');
+    sandbox.stub(temp2env);
 
     // clear the caches
     lib.getYaml.cache = new _.memoize.Cache();
@@ -160,7 +163,18 @@ describe(_.startCase(filename), function () {
   });
 
   describe('getYaml', function () {
-    var fn = lib[this.title];
+    var fn = lib[this.title],
+      myEnvFile = 'myEnvFile',
+      original;
+
+    beforeEach(function () {
+      original = lib.getAllowedEnvFiles;
+      lib.setAllowedEnvFiles([myEnvFile]);
+    });
+
+    afterEach(function () {
+      lib.setAllowedEnvFiles(original);
+    });
 
     it('returns result', function () {
       var filename = 'some-name',
@@ -191,6 +205,29 @@ describe(_.startCase(filename), function () {
       yaml.safeLoad.returnsArg(0);
 
       expect(fn(filename)).to.equal(result);
+    });
+
+    it('runs temp2env when filename allows env\'s', function () {
+      var result = 'some result';
+
+      fs.readFileSync.returns(result);
+      temp2env.interpolate.returns(result);
+
+      fn(myEnvFile);
+
+      sinon.assert.calledOnce(temp2env.interpolate);
+    });
+
+    it('doesn\'t run temp2env when filename doesn\'t allow env\'s', function () {
+      var filename = 'something different',
+        result = 'some result';
+
+      fs.readFileSync.returns(result);
+      temp2env.interpolate.returns(result);
+
+      fn(filename);
+
+      sinon.assert.notCalled(temp2env.interpolate);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "memdown": "^1.0.0",
     "multiplex-templates": "^1.2",
     "node-fetch": "^1.3",
+    "template2env": "^1.0.4",
     "through2-filter": "^2.0",
     "vhost": "^3.0.0",
     "winston": "^2.1"


### PR DESCRIPTION
We want devs to be able to add environment variables to configuration files in order to simplify having different configurations in different environments, e.g., (local, QA, prod).

`getYaml` will check if the file it's reading is either "config" or "local" and will use [temp2env](https://github.com/ughitsaaron/template2env) to interpolate variable names in the config file (denoted with `${}`s) with environment variables.