### PR TITLE
change all logs to winston

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -7,7 +7,7 @@ var path = require('path'),
   siteService = require('./services/sites'),
   references = require('./services/references'),
   db = require('./services/db'),
-  log = require('./log'),
+  log = require('./log').withStandardPrefix(__filename),
   chalk = require('chalk');
 
 _.mixin(require('lodash-ny-util'));
@@ -199,7 +199,7 @@ function load(data, site) {
   promiseListsOps = saveObjects(prefix + '/lists/', data.lists, getPutOperation);
   promiseUrisOps = saveBase64Strings(prefix + '/uris/', data.uris, getPutOperation);
   _.each(data.uris, function (page, uri) {
-    log.info('Bootstrapped: ' + chalk.blue(uri) + chalk.dim(' => ') + chalk.dim(page));
+    log('info', 'bootstrapped: ' + chalk.blue(uri) + chalk.dim(' => ') + chalk.dim(page));
   });
   promiseComponentsOps = saveWithInstances(prefix + '/components/', data.components, function (name, item) {
     return bluebird.join(
@@ -259,7 +259,7 @@ module.exports = function () {
   return bluebird.all(_.map(sites, function (site) {
     return bootstrapComponents(site).then(function () {
       return bootstrapPath(site.dir, site).catch(function (ex) {
-        log.error('Bootstrap error:' + ex.stack);
+        log('error', 'bootstrap error:', ex);
       });
     });
   }));

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
   siteService = require('./services/sites'),
   expect = require('chai').expect,
   sinon = require('sinon'),
-  log = require('./log');
+  winston = require('winston');
 
 describe(_.startCase(filename), function () {
   var sandbox,
@@ -39,7 +39,7 @@ describe(_.startCase(filename), function () {
   beforeEach(function () {
 
     sandbox = sinon.sandbox.create();
-    sandbox.stub(log);
+    sandbox.stub(winston);
     sandbox.stub(db, 'formatBatchOperations').returns([]);
     sandbox.stub(siteService);
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,12 +17,18 @@ function resolveComponentReferences(data, locals, filter) {
   var referenceObjects = _.listDeepObjects(data, filter || referenceProperty);
 
   return bluebird.all(referenceObjects).each(function (referenceObject) {
-    return components.get(referenceObject[referenceProperty], locals).then(function (obj) {
-      // the thing we got back might have its own references
-      return resolveComponentReferences(obj, locals, filter).finally(function () {
-        _.assign(referenceObject, _.omit(obj, referenceProperty));
+    return components.get(referenceObject[referenceProperty], locals)
+      .then(function (obj) {
+        // the thing we got back might have its own references
+        return resolveComponentReferences(obj, locals, filter).finally(function () {
+          _.assign(referenceObject, _.omit(obj, referenceProperty));
+        }).catch(function (error) {
+          // add additional information to the error message
+          const wrappedError = new Error(error.message + ' within ' + referenceObject[referenceProperty]);
+          wrappedError.name = error.name;
+          throw wrappedError;
+        });
       });
-    });
   }).return(data);
 }
 

--- a/lib/composer.test.js
+++ b/lib/composer.test.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash'),
   bluebird = require('bluebird'),
+  control = require('./control'),
   components = require('./services/components'),
   expect = require('chai').expect,
   filename = __filename.split('/').pop().split('.').shift(),
@@ -62,6 +63,24 @@ describe(_.startCase(filename), function () {
             }
           } }
         });
+      });
+    });
+
+    it('adds additional reference information to any errors that occur', function (done) {
+      const data = {
+        a: {_ref:'/c/b'},
+        c: {d: {_ref:'/c/e'}}
+      },
+        myError = control.setReadOnly(new Error('hello!'));
+
+      components.get.withArgs('/c/b').returns(bluebird.resolve({g: 'h'}));
+      components.get.withArgs('/c/e').returns(bluebird.resolve({i: 'j', k: {_ref:'/c/m'}}));
+      components.get.withArgs('/c/m').returns(bluebird.reject(myError));
+
+      return fn(data).then(done).catch(function (error) {
+        expect(error.message).to.equal('hello! within /c/e');
+        expect(error.message).to.match(/hello! within \/c\/e/);
+        done();
       });
     });
   });

--- a/lib/control.js
+++ b/lib/control.js
@@ -2,7 +2,7 @@
 
 var memoryLeakThreshold = 1000;
 const _ = require('lodash'),
-  log = require('./log'),
+  log = require('./log').withStandardPrefix(__filename),
   minute = 60000;
 
 /**
@@ -70,7 +70,7 @@ function defineWritable(definition) {
  * @param {object} cache
  */
 function reportMemoryLeak(fn, cache) {
-  log.warn('Memory leak', fn.name, cache);
+  log('warn', 'memory leak', fn.name, cache);
 }
 
 /**

--- a/lib/control.test.js
+++ b/lib/control.test.js
@@ -3,7 +3,7 @@
 const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
-  log = require('./log'),
+  winston = require('winston'),
   expect = require('chai').expect,
   sinon = require('sinon');
 
@@ -12,7 +12,7 @@ describe(_.startCase(filename), function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    sandbox.stub(log);
+    sandbox.stub(winston);
   });
 
   afterEach(function () {
@@ -68,7 +68,7 @@ describe(_.startCase(filename), function () {
       resultFn('b');
       resultFn('c');
 
-      sinon.assert.calledWith(log.warn, 'Memory leak', 'namedFn', { a: 'd', b: 'd', c: 'd' });
+      sinon.assert.calledWith(winston.log, 'warn');
     });
   });
 

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -168,7 +168,7 @@ describe(_.startCase(filename), function () {
       original;
 
     beforeEach(function () {
-      original = lib.getAllowedEnvFiles;
+      original = lib.getAllowedEnvFiles();
       lib.setAllowedEnvFiles([myEnvFile]);
     });
 

--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -11,7 +11,7 @@ const _ = require('lodash'),
   components = require('./services/components'),
   control = require('./control'),
   db = require('./services/db'),
-  log = require('./log'),
+  log = require('./log').withStandardPrefix(__filename),
   multiplexTemplates = require('multiplex-templates'),
   references = require('./services/references'),
   composer = require('./composer'),
@@ -214,11 +214,11 @@ function reducePageDataIntoLayoutComponentList(list, pageData) {
           items = items.concat(_.map(pageItem, refToObj));
         } else {
           // if it's an object or boolean, they're doing something weird
-          log.warn('Data is not a reference in layout: ', item, pageData, list);
+          log('warn', 'data is not a reference in layout:', item, pageData, list);
         }
       } else {
         // if there is no match, that's a problem with configuration/editing
-        log.warn('Missing reference in layout: ', item, pageData, list);
+        log('warn', 'missing reference in layout:', item, pageData, list);
       }
     } else {
       items.push(item);
@@ -335,15 +335,16 @@ function renderExpressRoute(req, res, next) {
     res.type('html');
     res.send(html);
 
-    log.info('rendered express route:' +
+    log('info', 'rendered express route:' +
       (req.hostname + req.baseUrl + req.path) + ' ' +
       ((process.hrtime()[1] - hrStart) / 1000000) + 'ms'
     );
-  }).catch(function (err) {
-    if (err.name === 'NotFoundError') {
+  }).catch(function (error) {
+    if (error.name === 'NotFoundError') {
+      log('verbose', 'in', req.uri, error.message);
       next();
     } else {
-      next(err);
+      next(error);
     }
   });
 }

--- a/lib/html-composer.test.js
+++ b/lib/html-composer.test.js
@@ -7,7 +7,7 @@ const _ = require('lodash'),
   db = require('./services/db'),
   bluebird = require('bluebird'),
   files = require('./files'),
-  log = require('./log'),
+  winston = require('winston'),
   plex = require('multiplex-templates'),
   siteService = require('./services/sites'),
   components = require('./services/components'),
@@ -57,7 +57,7 @@ describe(_.startCase(filename), function () {
     sandbox = sinon.sandbox.create();
 
     sandbox.stub(db);
-    sandbox.stub(log);
+    sandbox.stub(winston);
     sandbox.stub(components);
     sandbox.stub(plex, 'render');
     sandbox.stub(files, 'getComponentModule');
@@ -88,9 +88,10 @@ describe(_.startCase(filename), function () {
   });
 
   function expectNoLogging() {
-    sinon.assert.callCount(log.info, 0);
-    sinon.assert.callCount(log.warn, 0);
-    sinon.assert.callCount(log.error, 0);
+    sinon.assert.notCalled(winston.log);
+    sinon.assert.notCalled(winston.info);
+    sinon.assert.notCalled(winston.warn);
+    sinon.assert.notCalled(winston.error);
   }
 
   describe('renderComponent', function () {
@@ -229,7 +230,7 @@ describe(_.startCase(filename), function () {
       components.getTemplate.returns(template);
 
       return fn(pageRef, getMockRes()).then(function () {
-        expectCallCount(log, 'warn', 1);
+        sinon.assert.calledWith(winston.log, 'warn');
       });
     });
 
@@ -246,7 +247,7 @@ describe(_.startCase(filename), function () {
       components.getTemplate.returns(template);
 
       return fn(pageRef, getMockRes()).then(function () {
-        expectCallCount(log, 'warn', 1);
+        sinon.assert.calledWith(winston.log, 'warn');
       });
     });
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,10 +1,45 @@
 'use strict';
 
-var winston = require('winston');
+var _ = require('lodash'),
+  chalk = require('chalk'),
+  path = require('path'),
+  winston = require('winston'),
+  util = require('util'),
+  logLevel = process.env.LOG || 'info';
 
 // default to console logger, but pretty-print it
 winston.remove(winston.transports.Console);
-winston.add(winston.transports.Console, { colorize: true });
+winston.add(winston.transports.Console, {
+  colorize: true
+});
+winston.default.transports.console.level = logLevel;
 
-module.exports = winston;
+/**
+ * @param {*} obj
+ * @returns {boolean}
+ */
+function isError(obj) {
+  return _.isError(obj) || (_.isObject(obj) && obj.stack && _.endsWith(obj.name, 'Error'));
+}
 
+/**
+ * @param {string} dirname
+ * @returns {Function}
+ */
+module.exports.withStandardPrefix = function (dirname) {
+  const prefix = path.relative(process.cwd(), dirname);
+
+  return function (type) {
+    winston.log(type, _.reduce(_.slice(arguments, 1), function (list, value) {
+      if (isError(value)) {
+        list.push(value.stack);
+      } else if (_.isObject(value)) {
+        list.push(util.inspect(value, {showHidden: true, depth: 10}));
+      } else {
+        list.push(value + '');
+      }
+
+      return list;
+    }, [chalk.blue(prefix + '::')]).join(' '));
+  };
+};

--- a/lib/log.test.js
+++ b/lib/log.test.js
@@ -1,0 +1,44 @@
+'use strict';
+/* eslint max-nested-callbacks:[2,5] */
+
+var sinon = require('sinon'),
+  dirname = __dirname.split('/').pop(),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./' + filename),
+  winston = require('winston');
+
+describe(dirname, function () {
+  describe(filename, function () {
+    var sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(winston);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('withStandardPrefix', function () {
+      var fn = lib[this.title];
+
+      it('with object', function () {
+        const logFn = fn(__dirname);
+
+        logFn('log', 'a', {b: 'c', d: {e: 'f'}});
+
+        sinon.assert.calledOnce(winston.log);
+      });
+
+      it('with error', function () {
+        const logFn = fn(__dirname);
+
+        logFn('log', 'a', new Error('hello'));
+
+        sinon.assert.calledOnce(winston.log);
+      });
+
+    });
+  });
+});

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -9,7 +9,7 @@
 const _ = require('lodash'),
   db = require('./services/db'),
   bluebird = require('bluebird'),
-  log = require('./log'),
+  log = require('./log').withStandardPrefix(__filename),
   filter = require('through2-filter'),
   referencedProperty = '_ref';
 
@@ -308,7 +308,7 @@ function onlyAcceptExtensions(options) {
  */
 function serverError(err, res) {
   // error is required to be logged
-  log.error(err.stack);
+  log('error', err);
 
   var message = 'Server Error', //completely hide these messages from outside
     code = 500;

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
   expect = require('chai').expect,
   sinon = require('sinon'),
   bluebird = require('bluebird'),
-  log = require('./log'),
+  winston = require('winston'),
   filter = require('through2-filter'),
   createMockReq = require('../test/fixtures/mocks/req'),
   createMockRes = require('../test/fixtures/mocks/res');
@@ -29,10 +29,10 @@ describe(_.startCase(filename), function () {
    * Shortcut
    */
   function expectNoLogging() {
-    var logExpectations = sandbox.mock(log);
-    logExpectations.expects('info').never();
-    logExpectations.expects('warn').never();
-    logExpectations.expects('error').never();
+    sinon.assert.notCalled(winston.log);
+    sinon.assert.notCalled(winston.info);
+    sinon.assert.notCalled(winston.warn);
+    sinon.assert.notCalled(winston.error);
   }
 
   /**
@@ -61,6 +61,7 @@ describe(_.startCase(filename), function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(winston);
   });
 
   afterEach(function () {
@@ -97,18 +98,22 @@ describe(_.startCase(filename), function () {
     it('sends 404 if "not found"', function (done) {
       var res = createMockRes();
 
-      expectNoLogging();
       expectStatus(res, 404);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        expectNoLogging();
+        done();
+      });
       fn(res)(new Error('not found'));
     });
 
     it('sends 500 and logs error', function (done) {
       var res = createMockRes();
 
-      sandbox.mock(log).expects('error').once();
       expectStatus(res, 500);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        sinon.assert.calledWith(winston.log, 'error');
+        done();
+      });
       fn(res)(new Error('something'));
     });
   });
@@ -119,9 +124,11 @@ describe(_.startCase(filename), function () {
     it('sends 400', function (done) {
       var res = createMockRes();
 
-      expectNoLogging();
       expectStatus(res, 400);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        expectNoLogging();
+        done();
+      });
       fn(new Error('something'), res);
     });
   });
@@ -132,9 +139,11 @@ describe(_.startCase(filename), function () {
     it('sends 500 and logs error', function (done) {
       var res = createMockRes();
 
-      sandbox.mock(log).expects('error').once();
       expectStatus(res, 500);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        sinon.assert.calledWith(winston.log, 'error');
+        done();
+      });
       fn(new Error('something'), res);
     });
   });
@@ -145,9 +154,11 @@ describe(_.startCase(filename), function () {
     it('sends 501', function (done) {
       var res = createMockRes();
 
-      expectNoLogging();
       expectStatus(res, 501);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        expectNoLogging();
+        done();
+      });
       fn({}, res);
     });
   });
@@ -161,10 +172,11 @@ describe(_.startCase(filename), function () {
 
       req.path = '/hey';
 
-      expectNoLogging();
+
       sandbox.mock(res).expects('set').withArgs('Vary', 'whatever').once();
       fn({varyBy: ['whatever']})(req, res, function () {
         sandbox.verify();
+        expectNoLogging();
         done();
       });
     });
@@ -175,10 +187,10 @@ describe(_.startCase(filename), function () {
 
       req.path = '/hey.html';
 
-      expectNoLogging();
       sandbox.mock(res).expects('set').withArgs('Vary', sinon.match.any).never();
       fn({varyBy: ['whatever']})(req, res, function () {
         sandbox.verify();
+        expectNoLogging();
         done();
       });
     });
@@ -248,13 +260,15 @@ describe(_.startCase(filename), function () {
         res = createMockRes({formatter: 'json'});
       req.method = 'somethingElse';
 
-      expectNoLogging();
       expectStatus(res, 405);
       expectResult(res, {
         allow: allowed,
         code: 405,
         message: 'Method somethingElse not allowed'
-      }, done);
+      }, function () {
+        expectNoLogging();
+        done();
+      });
       fn({allow: allowed})(req, res);
     });
 
@@ -263,8 +277,10 @@ describe(_.startCase(filename), function () {
         res = createMockRes({formatter: 'json'});
       req.method = 'something';
 
-      expectNoLogging();
-      fn({allow: ['something']})(req, res, done);
+      fn({allow: ['something']})(req, res, function () {
+        expectNoLogging();
+        done();
+      });
     });
   });
 
@@ -275,8 +291,10 @@ describe(_.startCase(filename), function () {
       var data = {},
         res = createMockRes({formatter: 'json'});
 
-      expectNoLogging();
-      expectResult(res, data, done);
+      expectResult(res, data, function () {
+        expectNoLogging();
+        done();
+      });
       fn(function () {
         return data;
       }, res);
@@ -285,12 +303,14 @@ describe(_.startCase(filename), function () {
     it('404s on Error "not found"', function (done) {
       var res = createMockRes({formatter: 'json'});
 
-      expectNoLogging();
       expectStatus(res, 404);
       expectResult(res, {
         message: 'Not Found',
         code: 404
-      }, done);
+      }, function () {
+        expectNoLogging();
+        done();
+      });
       fn(function () {
         throw Error('something not found: etc etc');
       }, res);
@@ -304,19 +324,23 @@ describe(_.startCase(filename), function () {
       var data = 'some html',
         res = createMockRes({formatter: 'html'});
 
-      expectNoLogging();
       expectContentType(res, /html/);
-      expectResult(res, data, done);
+      expectResult(res, data, function () {
+        expectNoLogging();
+        done();
+      });
       fn(_.constant(data), res);
     });
 
     it('404s on Error "not found"', function (done) {
       var res = createMockRes({formatter: 'html'});
 
-      expectNoLogging();
       expectStatus(res, 404);
       expectContentType(res, /html/);
-      expectResult(res, '404 Not Found', done);
+      expectResult(res, '404 Not Found', function () {
+        expectNoLogging();
+        done();
+      });
       fn(function () {
         throw Error('something not found: etc etc');
       }, res);
@@ -347,8 +371,10 @@ describe(_.startCase(filename), function () {
       req.hostname = 'base.com';
       req.path = '/a';
 
-      expectNoLogging();
-      expectResult(res, '["base.com/aa","base.com/aaa"]', done);
+      expectResult(res, '["base.com/aa","base.com/aaa"]', function () {
+        expectNoLogging();
+        done();
+      });
       fn()(req, res);
     });
 
@@ -371,8 +397,10 @@ describe(_.startCase(filename), function () {
       req.hostname = 'base.com';
       req.path = '/';
 
-      expectNoLogging();
-      expectResult(res, '["base.com/c","base.com/cc","base.com/ccc"]', done);
+      expectResult(res, '["base.com/c","base.com/cc","base.com/ccc"]', function () {
+        expectNoLogging();
+        done();
+      });
       fn({transforms: [onlyCFilter]})(req, res);
     });
   });

--- a/lib/routes/lists.test.js
+++ b/lib/routes/lists.test.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
   responses = require('../responses'),
   sinon = require('sinon'),
   expect = require('chai').expect,
-  log = require('../log');
+  winston = require('winston');
 
 describe(_.startCase(filename), function () {
   var sandbox;
@@ -15,14 +15,15 @@ describe(_.startCase(filename), function () {
    * Shortcut
    */
   function expectNoLogging() {
-    var logExpectations = sandbox.mock(log);
-    logExpectations.expects('info').never();
-    logExpectations.expects('warn').never();
-    logExpectations.expects('error').never();
+    sinon.assert.notCalled(winston.log);
+    sinon.assert.notCalled(winston.info);
+    sinon.assert.notCalled(winston.warn);
+    sinon.assert.notCalled(winston.error);
   }
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(winston);
   });
 
   afterEach(function () {
@@ -37,13 +38,13 @@ describe(_.startCase(filename), function () {
         req = {},
         res = {};
 
-      expectNoLogging();
       sandbox.stub(responses, 'clientError');
 
       fn(req, res, next);
 
       expect(next.called).to.equal(true);
       expect(responses.clientError.called).to.equal(false);
+      expectNoLogging();
     });
 
     it('allows array body', function () {
@@ -51,7 +52,6 @@ describe(_.startCase(filename), function () {
         req = {},
         res = {};
 
-      expectNoLogging();
       req.body = [];
       sandbox.stub(responses, 'clientError');
 
@@ -59,6 +59,7 @@ describe(_.startCase(filename), function () {
 
       expect(next.called).to.equal(true);
       expect(responses.clientError.called).to.equal(false);
+      expectNoLogging();
     });
 
     it('error when req.body is object', function () {
@@ -66,7 +67,6 @@ describe(_.startCase(filename), function () {
         req = {},
         res = {};
 
-      expectNoLogging();
       req.body = {};
       sandbox.stub(responses, 'clientError');
 
@@ -74,6 +74,7 @@ describe(_.startCase(filename), function () {
 
       expect(next.called).to.equal(false);
       expect(responses.clientError.callCount).to.equal(1);
+      expectNoLogging();
     });
   });
 });

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -10,7 +10,7 @@ var _ = require('lodash'),
   glob = require('glob'),
   bluebird = require('bluebird'),
   expect = require('chai').expect,
-  log = require('../log');
+  winston = require('winston');
 
 describe(_.startCase(filename), function () {
   var sandbox;
@@ -19,9 +19,10 @@ describe(_.startCase(filename), function () {
    * Shortcut
    */
   function assertNoLogging() {
-    sinon.assert.notCalled(log.info);
-    sinon.assert.notCalled(log.warn);
-    sinon.assert.notCalled(log.error);
+    sinon.assert.notCalled(winston.log);
+    sinon.assert.notCalled(winston.info);
+    sinon.assert.notCalled(winston.warn);
+    sinon.assert.notCalled(winston.error);
   }
 
   beforeEach(function () {
@@ -29,7 +30,7 @@ describe(_.startCase(filename), function () {
 
     sandbox.stub(siteService);
     sandbox.stub(files);
-    sandbox.stub(log);
+    sandbox.stub(winston);
 
     lib.getPossibleTemplates.cache = new _.memoize.Cache();
     lib.getSchema.cache = new _.memoize.Cache();

--- a/lib/services/notifications.js
+++ b/lib/services/notifications.js
@@ -3,7 +3,7 @@
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   contentType = 'Content-type',
-  log = require('../log'),
+  log = require('../log').withStandardPrefix(__filename),
   rest = require('../rest');
 
 /**
@@ -30,7 +30,7 @@ function callWebhook(event, url, data) {
   }
 
   return rest.fetch(url, options).then(function (response) {
-    log.info('called webhook', _.pick(response, ['status', 'statusText']));
+    log('info', 'called webhook', _.pick(response, ['status', 'statusText']));
   });
 }
 

--- a/lib/services/notifications.test.js
+++ b/lib/services/notifications.test.js
@@ -4,7 +4,7 @@ var _ = require('lodash'),
   expect = require('chai').expect,
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
-  log = require('../log'),
+  winston = require('winston'),
   rest = require('../rest'),
   sinon = require('sinon');
 
@@ -15,7 +15,7 @@ describe(_.startCase(filename), function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(rest);
-    sandbox.stub(log);
+    sandbox.stub(winston);
   });
 
   afterEach(function () {

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -5,7 +5,7 @@ var interval,
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   db = require('../services/db'),
-  log = require('../log'),
+  log = require('../log').withStandardPrefix(__filename),
   publishProperty = 'publish',
   references = require('../services/references'),
   rest = require('../rest'),
@@ -34,7 +34,7 @@ function publishExternally(url) {
     return rest.getObject(latest).then(function (data) {
       return rest.putObject(published, data);
     }).then(function () {
-      log.info('published', latest);
+      log('info', 'published', latest);
     });
   });
 }
@@ -52,7 +52,7 @@ function getPublishableItems(list, now) {
       item.value = item.value && JSON.parse(item.value);
       return item;
     } catch (ex) {
-      log.error('Cannot parse JSON of ' + item.value);
+      log('error', 'Cannot parse JSON of', item.value);
     }
   }));
 
@@ -164,7 +164,7 @@ function startListening() {
         })).then(JSON.parse)
           .then(publishEachByTime)
           .catch(function (error) {
-            log.error('failed to publish', error);
+            log('error', 'failed to publish', error);
           });
       });
     }, intervalDelay);

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
   expect = require('chai').expect,
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
-  log = require('../log'),
+  winston = require('winston'),
   rest = require('../rest'),
   sinon = require('sinon'),
   siteService = require('./sites'),
@@ -25,7 +25,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(db, 'batch');
     sandbox.stub(db, 'pipeToPromise');
     sandbox.stub(siteService, 'sites');
-    sandbox.stub(log);
+    sandbox.stub(winston);
     sandbox.stub(uid);
     sandbox.stub(rest);
   });
@@ -132,8 +132,8 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      log.error = done;
-      log.info = function () {
+      winston.log = function (logType) {
+        expect(logType).to.equal('info');
         done();
       };
     });
@@ -150,9 +150,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      log.info = done;
-      log.error = function (msg) {
-        expect(msg).to.equal('failed to publish');
+      winston.log = function (logType, msg) {
+        expect(logType).to.equal('error');
+        expect(msg).to.match(/failed to publish/);
         done();
       };
     });
@@ -176,9 +176,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      log.info = done;
-      log.error = function (msg) {
-        expect(msg).to.equal('failed to publish');
+      winston.log = function (logType, msg) {
+        expect(logType).to.equal('error');
+        expect(msg).to.match(/failed to publish/);
         done();
       };
     });
@@ -194,8 +194,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      log.info = done;
-      log.error = function () {
+      winston.log = function (logType, msg) {
+        expect(logType).to.equal('error');
+        expect(msg).to.match(/failed to publish/);
         done();
       };
     });
@@ -211,8 +212,9 @@ describe(_.startCase(filename), function () {
 
       sandbox.clock.tick(intervalDelay);
 
-      log.info = done;
-      log.error = function () {
+      winston.log = function (logType, msg) {
+        expect(logType).to.equal('error');
+        expect(msg).to.match(/failed to publish/);
         done();
       };
     });

--- a/lib/streams/sitemap-text-transform.js
+++ b/lib/streams/sitemap-text-transform.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-var log = require('../log'),
+var log = require('../log').withStandardPrefix(__filename),
   util = require('util'),
   Transform = require('stream').Transform;
 
@@ -25,7 +25,7 @@ SitemapTextTransform.prototype._transform = function (item, enc, cb) {
     this.push(JSON.parse(item.value).url + '\n');
   } catch (ex) {
     // eat errors, because pipes otherwise 'unpipe' the parent stream and stop streaming.
-    log.warn('SitemapTextTransform', ex.message);
+    log('warn', 'SitemapTextTransform', ex.message);
   }
   cb();
 };

--- a/lib/streams/sitemap-xml-transform.js
+++ b/lib/streams/sitemap-xml-transform.js
@@ -11,7 +11,7 @@ const _ = require('lodash'),
   components = require('../services/components'),
   composer = require('../composer'),
   db = require('../services/db'),
-  log = require('../log'),
+  log = require('../log').withStandardPrefix(__filename),
   multiplexTemplates = require('multiplex-templates'),
   references = require('../services/references'),
   util = require('util'),
@@ -104,7 +104,7 @@ function renderXMLComponentsAsList(componentReference) {
         }
       }).join('');
     }).catch(function (ex) {
-      log.warn('Encountered error while rendering sitemap for', componentReference, ex.stack);
+      log('warn', 'Encountered error while rendering sitemap for', componentReference, ex.stack);
       return '';
     });
 }
@@ -167,10 +167,10 @@ SitemapXmlTransform.prototype._transform = function (item, enc, cb) {
     }
     stream.push(xml);
   }).catch({name: 'NotFoundError'}, function (error) {
-    log.warn('NotFoundError', error.stack);
+    log('warn', error);
   }).catch(function (error) {
     //eat error because we don't want to unpipe the parent stream or stop streaming
-    log.warn('Error', error.stack);
+    log('warn', error);
   }).finally(cb);
 };
 SitemapXmlTransform.prototype._flush = function (cb) {

--- a/test/api/sitemaps/txt.js
+++ b/test/api/sitemaps/txt.js
@@ -7,7 +7,7 @@ const _ = require('lodash'),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
   files = require('../../../lib/files'),
   hostname = 'some-hostname',
-  log = require('../../../lib/log'),
+  winston = require('winston'),
   sinon = require('sinon'),
   routes = require('../../../lib/routes'),
   request = require('supertest-as-promised');
@@ -41,7 +41,7 @@ describe(endpointName, function () {
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       sandbox.stub(files, 'fileExists');
-      sandbox.stub(log);
+      sandbox.stub(winston);
 
       files.fileExists.withArgs('public').returns(true);
 
@@ -86,7 +86,7 @@ describe(endpointName, function () {
           .expect('Content-Type', /text/)
           .expect('http://some-url/d\nhttp://some-url/e\n')
           .then(function () {
-            sinon.assert.calledOnce(log.warn);
+            sinon.assert.calledWith(winston.log, 'warn');
           });
       });
     });

--- a/test/api/sitemaps/xml.js
+++ b/test/api/sitemaps/xml.js
@@ -9,7 +9,7 @@ const _ = require('lodash'),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
   files = require('../../../lib/files'),
   hostname = 'some-hostname',
-  log = require('../../../lib/log'),
+  winston = require('winston'),
   multiplexTemplates = require('multiplex-templates'),
   sinon = require('sinon'),
   routes = require('../../../lib/routes'),
@@ -55,7 +55,7 @@ describe(endpointName, function () {
       sandbox.stub(components, 'getTemplate');
       sandbox.stub(files, 'fileExists');
       sandbox.stub(multiplexTemplates, 'render');
-      sandbox.stub(log);
+      sandbox.stub(winston);
 
       header = '<?xml version="1.0" encoding="UTF-8"?>' +
         '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
@@ -105,7 +105,7 @@ describe(endpointName, function () {
           '<url><loc>http://some-url/e</loc></url>' +
           footer)
         .then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -120,7 +120,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc><lastmod>2015-01-01T00:00:00.000Z</lastmod></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -135,7 +135,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc><lastmod>some time string</lastmod></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -150,7 +150,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc><priority>1.0</priority></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -165,7 +165,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc><changefreq>never</changefreq></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -181,7 +181,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/e</loc></url>' +
             footer)
           .then(function () {
-            sinon.assert.calledOnce(log.warn);
+            sinon.assert.calledWith(winston.log, 'warn');
           });
       });
     });
@@ -196,7 +196,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/e</loc></url>' +
             footer);
         }).then(function () {
-          sinon.assert.calledOnce(log.warn);
+          sinon.assert.calledWith(winston.log, 'warn');
         });
     });
 
@@ -218,7 +218,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc><def></def></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -240,7 +240,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc></url>' +
             footer);
         }).then(function () {
-          sinon.assert.calledOnce(log.warn);
+          sinon.assert.calledWith(winston.log, 'warn');
         });
     });
 
@@ -261,7 +261,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/f</loc></url>' +
             footer);
         }).then(function () {
-          sinon.assert.notCalled(log.warn);
+          sinon.assert.notCalled(winston.log);
         });
     });
 
@@ -282,7 +282,7 @@ describe(endpointName, function () {
             '<url><loc>http://some-url/e</loc></url>' +
             footer);
         }).then(function () {
-          sinon.assert.calledOnce(log.warn);
+          sinon.assert.calledWith(winston.log, 'warn');
         });
     });
   });


### PR DESCRIPTION
Patch
- change all logs to winston
- make all logs consistent in how they report their filename
- report when `LOG=verbose` what reference is missing for 404s.