### PR TITLE
add-batch-validation

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -12,7 +12,8 @@ var _ = require('lodash'),
   bluebird = require('bluebird'),
   jsonTransform = require('./../streams/json-transform'),
   chalk = require('chalk'),
-  Eventify = require('eventify');
+  Eventify = require('eventify'),
+  validation = require('../validation');
 
 /**
  * Use ES6 promises
@@ -145,7 +146,9 @@ function list(options) {
  * @returns {Promise}
  */
 function batch(ops, options) {
-  var deferred = defer();
+  validation.assertValidBatchOps(ops);
+  const deferred = defer();
+
   db.batch(ops, options || {}, deferred.apply);
   return deferred.promise;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,9 +1,14 @@
 'use strict';
 
-var express = require('express'),
+var bluebird = require('bluebird'),
+  express = require('express'),
   routes = require('./routes'),
   bootstrap = require('./bootstrap'),
   htmlComposer = require('./html-composer');
+
+bluebird.config({
+  longStackTraces: true
+});
 
 /**
  * optionally pass in an express app and/or templating engines

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const _ = require('lodash');
+
+function validateBatchOp(op) {
+  const errors = [];
+
+  if (!_.isString(op.type)) {
+    errors.push('Missing type in batch operation, can be "put" or "del"');
+  }
+
+  if (!_.isString(op.key)) {
+    errors.push('Missing key in batch operation');
+  }
+
+  if (_.isString(op.value) && op.value[0] === '"') {
+    errors.push('Double-stringified value in batch operation');
+  } else if (!_.isString(op.value) && op.type !== 'del') {
+    errors.push('Missing value in batch operation');
+  }
+
+  return errors;
+}
+
+function validateBatchOps(ops) {
+  return _.flatten(_.map(ops, validateBatchOp));
+}
+
+/**
+ * @param ops
+ * @returns ops
+ * @throws if ops are invalid
+ */
+function assertValidBatchOps(ops) {
+  const errors = validateBatchOps(ops);
+
+  if (errors.length) {
+    throw new Error('Invalid batch ops:\n  ' + errors.join('\n  '));
+  }
+
+  return ops;
+}
+
+module.exports.validateBatchOp = validateBatchOp;
+module.exports.validateBatchOps = validateBatchOps;
+module.exports.assertValidBatchOps = assertValidBatchOps;

--- a/lib/validation.test.js
+++ b/lib/validation.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+var _ = require('lodash'),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./' + filename),
+  expect = require('chai').expect,
+  sinon = require('sinon');
+
+describe(_.startCase(filename), function () {
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('assertValidBatchOps', function () {
+    const fn = lib[this.title];
+
+    it('does not throw with no errors', function () {
+      const ops = [
+          { type: 'a', key: 'b', value: 'c' },
+          { type: 'd', key: 'e', value: 'f' }
+        ];
+
+      expect(function () {
+        fn(ops);
+      }).to.not.throw(Error);
+    });
+
+    it('throws with errors', function () {
+      const ops = [
+          { key: 'b', value: 'c' },
+          { type: 'd', value: 'f' }
+        ];
+
+      expect(function () {
+        fn(ops);
+      }).to.throw(Error);
+    });
+  });
+
+  describe('validateBatchOps', function () {
+    const fn = lib[this.title];
+
+    it('get multiple errors', function () {
+      const ops = [
+          { key: 'b', value: 'c' },
+          { type: 'd', value: 'f' }
+        ],
+        errors = [
+          'Missing type in batch operation, can be "put" or "del"',
+          'Missing key in batch operation'
+        ];
+
+      expect(fn(ops)).to.deep.equal(errors);
+    });
+  });
+
+  describe('validateBatchOp', function () {
+    const fn = lib[this.title];
+
+    it('returns empty array when no errors', function () {
+      const op = {
+          type: 'a',
+          key: 'b',
+          value: 'c'
+        },
+        errors = [];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+
+    it('returns error when missing type', function () {
+      const op = {
+          key: 'b',
+          value: 'c'
+        },
+        errors = ['Missing type in batch operation, can be "put" or "del"'];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+
+    it('returns error when missing key', function () {
+      const op = {
+          type: 'a',
+          value: 'c'
+        },
+        errors = ['Missing key in batch operation'];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+
+    it('returns error when missing value', function () {
+      const op = {
+          type: 'a',
+          key: 'b'
+        },
+        errors = ['Missing value in batch operation'];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+
+    it('does not return error when missing value but type is "del"', function () {
+      const op = {
+          type: 'del',
+          key: 'b'
+        },
+        errors = [];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+
+    it('returns empty array when no errors', function () {
+      const op = {
+          type: 'a',
+          key: 'b',
+          value: JSON.stringify('c')
+        },
+        errors = ['Double-stringified value in batch operation'];
+
+      expect(fn(op)).to.deep.equal(errors);
+    });
+  });
+});


### PR DESCRIPTION
Patch
- add batch validation, such that doubly-stringified objects will return an error.