### PR TITLE
better/sooner error messaging when templating eats an exception

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -63,7 +63,7 @@ function splice(str, index, items) {
  *
  * @param {{styles: Array, scripts: Array}} mediaMap
  * @param {string} html
- * @returns {function}
+ * @returns {string}
  */
 function appendMediaToTop(mediaMap, html) {
   var index = findTop(html),
@@ -80,7 +80,7 @@ function appendMediaToTop(mediaMap, html) {
  * Append at the bottom of the body tag, or if no body tag, then the bottom of the root tag.
  * @param {{styles: Array, scripts: Array}} mediaMap
  * @param {string} html
- * @returns {function}
+ * @returns {string}
  */
 function appendMediaToBottom(mediaMap, html) {
   var index = findBottom(html),
@@ -98,20 +98,29 @@ function appendMediaToBottom(mediaMap, html) {
  * @returns {object}
  */
 function append(data) {
-  var mediaMap = data[mediaMapProperty],
-    tasks = [];
+  const mediaMap = data[mediaMapProperty];
 
-  if (mediaMap) {
+  // assertion
+  if (!_.isObject(mediaMap)) {
+    return _.identity;
+  }
+
+  return function (html) {
+    // assertion
+    if (!_.isString(html)) {
+      throw new Error('Missing html parameter');
+    }
+
     if (mediaMap.styles && mediaMap.styles.length > 0) {
-      tasks.push(_.partial(appendMediaToTop, mediaMap));
+      html = appendMediaToTop(mediaMap, html);
     }
 
     if (mediaMap.scripts && mediaMap.scripts.length > 0) {
-      tasks.push(_.partial(appendMediaToBottom, mediaMap));
+      html = appendMediaToBottom(mediaMap, html);
     }
-  }
 
-  return _.compose.apply(_, tasks);
+    return html;
+  };
 }
 
 /**

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -39,6 +39,22 @@ describe(_.startCase(filename), function () {
   describe('append', function () {
     const fn = lib[this.title];
 
+    it('does not throw when missing mediaMap', function () {
+      components.getStyles.onCall(0).returns([]);
+
+      expect(function () {
+        fn({})(basicHtml);
+      }).to.not.throw();
+    });
+
+    it('throws when missing html', function () {
+      components.getStyles.onCall(0).returns([]);
+
+      expect(function () {
+        fn(mediaMap({scripts:[], styles: []}))();
+      }).to.throw('Missing html parameter');
+    });
+
     it('adds nothing to bottom of head when no styles', function () {
       components.getStyles.onCall(0).returns([]);
 

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -49,7 +49,13 @@ function get(uri, locals) {
     promise = db.get(uri).then(JSON.parse);
   }
 
-  return promise;
+  return promise.then(function (data) {
+    if (!_.isObject(data)) {
+      throw new Error('Client: Invalid data type for component at ' + uri + ' of ' + (typeof data));
+    }
+
+    return data;
+  });
 }
 
 /**

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -364,6 +364,14 @@ describe(_.startCase(filename), function () {
       return fn('domain.com/path/components/whatever');
     });
 
+    it('blocks get that returns non-object', function (done) {
+      sandbox.stub(db, 'get').returns(bluebird.resolve('"a"'));
+      files.getComponentModule.withArgs('whatever').returns(null);
+      fn('domain.com/path/components/whatever').then(done).catch(function () {
+        done();
+      });
+    });
+
     it('gets even with bad name', function () {
       sandbox.stub(db, 'get').returns(bluebird.resolve('{}'));
       files.getComponentModule.withArgs('whatever').returns(null);
@@ -372,7 +380,7 @@ describe(_.startCase(filename), function () {
 
     it('gets using component module', function () {
       const ref = 'domain.com/path/components/whatever',
-        someModule = sinon.spy(_.constant(bluebird.resolve('{}')));
+        someModule = sinon.spy(_.constant(bluebird.resolve({})));
 
       files.getComponentModule.returns(someModule);
       return fn(ref).then(function () {
@@ -381,10 +389,20 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('blocks component module returning non-object', function (done) {
+      const ref = 'domain.com/path/components/whatever',
+        someModule = sinon.spy(_.constant(bluebird.resolve('{}')));
+
+      files.getComponentModule.returns(someModule);
+      fn(ref).then(done).catch(function () {
+        done();
+      });
+    });
+
     it('gets using component module with locals', function () {
       const ref = 'domain.com/path/components/whatever',
         locals = {},
-        someModule = sinon.spy(_.constant(bluebird.resolve('{}')));
+        someModule = sinon.spy(_.constant(bluebird.resolve({})));
 
       files.getComponentModule.returns(someModule);
       return fn(ref, locals).then(function () {


### PR DESCRIPTION
Patch:

In certain cases, the templating engine has an error, and then it eats it, returning undefined.

Amphora's mediaMap should recognize that it is not being given what it expected, and say so.