### PR TITLE
fix-timer

### DIFF
--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -326,7 +326,7 @@ function getExpressRoutePrefix(site) {
 function renderExpressRoute(req, res, next) {
   var site, prefix, pageReference, hrStart;
 
-  hrStart = process.hrtime()[1];
+  hrStart = process.hrtime();
   site = res.locals.site;
   prefix = getExpressRoutePrefix(site) + '/uris/';
   pageReference = prefix + new Buffer(req.hostname + req.baseUrl + req.path).toString('base64');
@@ -335,10 +335,9 @@ function renderExpressRoute(req, res, next) {
     res.type('html');
     res.send(html);
 
-    log('info', 'rendered express route:' +
-      (req.hostname + req.baseUrl + req.path) + ' ' +
-      ((process.hrtime()[1] - hrStart) / 1000000) + 'ms'
-    );
+    const diff = process.hrtime(hrStart),
+      ms = Math.floor((diff[0] * 1e9 + diff[1]) / 1000000);
+    log('info', 'rendered express route:' + (req.hostname + req.baseUrl + req.path) + ' ' + ms + 'ms');
   }).catch(function (error) {
     if (error.name === 'NotFoundError') {
       log('verbose', 'in', req.uri, error.message);


### PR DESCRIPTION
Patch
- Currently, the performance metric for rendering a page sometimes shows negative values.
- By passing the hrtime into itself, node.js handles creating the diff for us.



