### PR TITLE
log timeout and slow

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -27,7 +27,7 @@ function isError(obj) {
  * @returns {Function}
  */
 module.exports.withStandardPrefix = function (dirname) {
-  const prefix = path.relative(process.cwd(), dirname);
+  const prefix = path.relative(process.cwd(), dirname).replace(/\.js$/, '').replace(/^[\.]\.\//, '');
 
   return function (type) {
     winston.log(type, _.reduce(_.slice(arguments, 1), function (list, value) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -83,7 +83,7 @@ function addControllerRoutes(router) {
     pathRouter = express.Router();
 
     // assume json or text for anything in request bodies
-    pathRouter.use(require('body-parser').json({strict: true, type: 'application/json'}));
+    pathRouter.use(require('body-parser').json({strict: true, type: 'application/json', limit: '50mb'}));
     pathRouter.use(require('body-parser').text({type: 'text/*'}));
 
     controller(pathRouter);

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-let timeoutConstant = 2000;
+let timeoutConstant = 4000;
 const _ = require('lodash'),
   control = require('../control'),
   db = require('./db'),

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -6,11 +6,14 @@
 
 'use strict';
 
-var _ = require('lodash'),
+let timeoutConstant = 2000;
+const _ = require('lodash'),
   control = require('../control'),
   db = require('./db'),
   uid = require('../uid'),
   files = require('../files'),
+  timer = require('../timer'),
+  log = require('../log').withStandardPrefix(__filename),
   schema = require('../schema'),
   siteService = require('./sites'),
   references = require('./references'),
@@ -18,7 +21,23 @@ var _ = require('lodash'),
   path = require('path'),
   glob = require('glob'),
   referenceProperty = '_ref',
-  mediaDir = path.join(process.cwd(), 'public');
+  mediaDir = path.join(process.cwd(), 'public'),
+  timeoutGetCoefficient = 2,
+  timeoutPutCoefficient = 5;
+
+/**
+ * @returns {number}
+ */
+function getTimeoutConstant() {
+  return timeoutConstant;
+}
+
+/**
+ * @param {number} value
+ */
+function setTimeoutConstant(value) {
+  timeoutConstant = value;
+}
 
 /**
  * Takes a ref, and returns the component name within it.
@@ -44,7 +63,20 @@ function get(uri, locals) {
     componentModule = name && files.getComponentModule(name);
 
   if (_.isFunction(componentModule)) {
-    promise = componentModule(uri, locals);
+    const startTime = process.hrtime(),
+      timeoutLimit = timeoutConstant * timeoutGetCoefficient;
+
+    promise = bluebird.try(function () { return componentModule(uri, locals); }).tap(function (result) {
+      const ms = timer.getMillisecondsSince(startTime);
+
+      if (!_.isObject(result)) {
+        throw new Error('Component module must return object, not ' + typeof result + ': ' + uri);
+      }
+
+      if (ms > timeoutLimit * 0.5) {
+        log('warn', 'slow get', uri, ms + 'ms');
+      }
+    }).timeout(timeoutLimit, 'Component module GET exceeded ' + timeoutLimit + 'ms:' + uri);
   } else {
     promise = db.get(uri).then(JSON.parse);
   }
@@ -142,7 +174,18 @@ function put(uri, data, locals) {
     componentModule = files.getComponentModule(getName(uri));
 
   if (componentModule && _.isFunction(componentModule.put)) {
-    result = componentModule.put(uri, data, locals);
+    const startTime = process.hrtime(),
+      timeoutLimit = timeoutConstant * timeoutPutCoefficient;
+
+    result = bluebird.try(function () {
+      return componentModule.put(uri, data, locals);
+    }).tap(function () {
+      const ms = timer.getMillisecondsSince(startTime);
+
+      if (ms > timeoutLimit * 0.5) {
+        log('warn', 'slow put', uri, ms + 'ms');
+      }
+    }).timeout(timeoutLimit, 'Component module PUT exceeded ' + timeoutLimit + 'ms:' + uri);
   } else {
     result = putDefaultBehavior(uri, data);
   }
@@ -260,17 +303,22 @@ function getPutOperations(uri, data, locals) {
  */
 function cascadingPut(uri, data, locals) {
   // split data into pieces
-  return getPutOperations(uri, data, locals)
-    .then(function (ops) {
-      // return ops if successful
-      return db.batch(ops).return(ops);
-    })
-    .then(function (ops) {
+  return getPutOperations(uri, data, locals).then(function (ops) {
+
+    // PUT operations have to put something, otherwise the operation is not a put -- if they got this far, it is
+    // the component's fault, not the client.  If it is a client error, an assertion should have caught this sooner.
+    if (!ops.length) {
+      throw new Error('Component module PUT failed to create batch operations: ' + uri);
+    }
+
+    // return ops if successful
+    return db.batch(ops).then(function () {
       // return the value of the last batch operation (the root object) if successful
       const rootOp = _.last(ops);
 
       return rootOp && JSON.parse(rootOp.value);
     });
+  });
 }
 
 /**
@@ -463,3 +511,7 @@ module.exports.getStyles = control.memoize(getStyles, joinArguments);
 // data rearrangement
 module.exports.getIndices = getIndices;
 module.exports.getPutOperations = getPutOperations;
+
+// dependency injection
+module.exports.setTimeoutConstant = setTimeoutConstant;
+module.exports.getTimeoutConstant = getTimeoutConstant;

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -7,23 +7,16 @@ var _ = require('lodash'),
   files = require('../files'),
   siteService = require('./sites'),
   db = require('./db'),
+  timer = require('../timer'),
   glob = require('glob'),
   bluebird = require('bluebird'),
   expect = require('chai').expect,
   winston = require('winston');
 
 describe(_.startCase(filename), function () {
-  var sandbox;
-
-  /**
-   * Shortcut
-   */
-  function assertNoLogging() {
-    sinon.assert.notCalled(winston.log);
-    sinon.assert.notCalled(winston.info);
-    sinon.assert.notCalled(winston.warn);
-    sinon.assert.notCalled(winston.error);
-  }
+  const timeoutConstant = 100;
+  let sandbox,
+    savedTimeoutConstant;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
@@ -31,16 +24,20 @@ describe(_.startCase(filename), function () {
     sandbox.stub(siteService);
     sandbox.stub(files);
     sandbox.stub(winston);
+    sandbox.stub(timer);
 
     lib.getPossibleTemplates.cache = new _.memoize.Cache();
     lib.getSchema.cache = new _.memoize.Cache();
     lib.getScripts.cache = new _.memoize.Cache();
     lib.getStyles.cache = new _.memoize.Cache();
+
+    savedTimeoutConstant = lib.getTimeoutConstant();
+    lib.setTimeoutConstant(timeoutConstant);
   });
 
   afterEach(function () {
-    assertNoLogging();
     sandbox.restore();
+    lib.setTimeoutConstant(savedTimeoutConstant);
   });
 
   describe('getName', function () {
@@ -244,8 +241,36 @@ describe(_.startCase(filename), function () {
   describe('put', function () {
     var fn = lib[this.title];
 
-    it('throws error if component module does not return promise', function () {
+    it('throw exception if module does not return any ops', function (done) {
+      var ref = 'a',
+        data = {},
+        putSpy = sinon.stub();
 
+      putSpy.withArgs('a', sinon.match.object).returns([]);
+      files.getComponentModule.returns({put: putSpy});
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
+
+      fn(ref, data).then(done).catch(function (error) {
+        expect(error.message).to.equal('Component module PUT failed to create batch operations: a');
+        done();
+      });
+    });
+
+    it('logs warning if operation is slow', function () {
+      var ref = 'a',
+        data = {},
+        putSpy = sinon.stub(),
+        moduleDataValue = {b: 'c'},
+        moduleData = { key: 'a', type: 'put', value: JSON.stringify(moduleDataValue) };
+
+      timer.getMillisecondsSince.returns(timeoutConstant * 7);
+      putSpy.withArgs('a', sinon.match.object).returns([moduleData]);
+      files.getComponentModule.returns({put: putSpy});
+      sandbox.stub(db, 'batch').returns(bluebird.resolve());
+
+      return fn(ref, data).then(function () {
+        sinon.assert.calledWith(winston.log, 'warn', sinon.match('slow put a 700ms'));
+      });
     });
 
     it('puts', function () {
@@ -394,8 +419,21 @@ describe(_.startCase(filename), function () {
         someModule = sinon.spy(_.constant(bluebird.resolve('{}')));
 
       files.getComponentModule.returns(someModule);
-      fn(ref).then(done).catch(function () {
+      fn(ref).then(done).catch(function (error) {
+        expect(error.message).to.equal('Component module must return object, not string: domain.com/path/components/whatever');
         done();
+      });
+    });
+
+    it('logs warning for slow component', function () {
+      const ref = 'domain.com/path/components/whatever',
+        someModule = sinon.spy(_.constant(bluebird.resolve({})));
+
+      timer.getMillisecondsSince.returns(timeoutConstant * 3);
+
+      files.getComponentModule.returns(someModule);
+      return fn(ref).then(function () {
+        sinon.assert.calledWith(winston.log, 'warn', sinon.match('slow get domain.com/path/components/whatever 300ms'));
       });
     });
 

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let timeoutConstant = 2000;
+let timeoutConstant = 4000;
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   components = require('../services/components'),

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let timeoutConstant = 2000;
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   components = require('../services/components'),
@@ -9,7 +10,23 @@ const _ = require('lodash'),
   notifications = require('./notifications'),
   references = require('../services/references'),
   siteService = require('./sites'),
-  uid = require('../uid');
+  timer = require('../timer'),
+  uid = require('../uid'),
+  timeoutPublishCoefficient = 5;
+
+/**
+ * @param {number} value
+ */
+function setTimeoutConstant(value) {
+  timeoutConstant = value;
+}
+
+/**
+ * @returns {number}
+ */
+function getTimeoutConstant() {
+  return timeoutConstant;
+}
 
 /**
  * @param {string} uri
@@ -193,8 +210,10 @@ function assertNoEmptyValues(data) {
  * @returns {Promise}
  */
 function publish(uri, data, locals) {
-  const prefix = references.getPagePrefix(uri),
-    site = getSite(prefix, locals);
+  const startTime = process.hrtime(),
+    prefix = references.getPagePrefix(uri),
+    site = getSite(prefix, locals),
+    timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
 
   return bluebird.try(function () {
     if (data && _.size(data) > 0) {
@@ -230,7 +249,13 @@ function publish(uri, data, locals) {
         // add page PUT operation last
         return addOp(references.replaceVersion(uri, published), pageData, ops);
       });
-  }).then(applyBatch(site));
+  }).then(applyBatch(site)).tap(function () {
+    const ms = timer.getMillisecondsSince(startTime);
+    
+    if (ms > timeoutLimit * 0.5) {
+      log('warn', 'slow publish', uri, ms + 'ms');
+    }
+  }).timeout(timeoutLimit, 'Page publish exceeded ' + timeoutLimit + 'ms:' + uri);
 }
 
 /**
@@ -268,3 +293,6 @@ function create(uri, data, locals) {
 module.exports.create = create;
 module.exports.publish = publish;
 module.exports.replacePageReferenceVersions = replacePageReferenceVersions;
+
+module.exports.getTimeoutConstant = getTimeoutConstant;
+module.exports.setTimeoutConstant = setTimeoutConstant;

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -10,10 +10,13 @@ var _ = require('lodash'),
   notifications = require('./notifications'),
   sinon = require('sinon'),
   siteService = require('./sites'),
+  timer = require('../timer'),
   winston = require('winston');
 
 describe(_.startCase(filename), function () {
-  var sandbox;
+  const timeoutConstant = 100;
+  let sandbox,
+    savedTimeoutConstant;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
@@ -21,11 +24,17 @@ describe(_.startCase(filename), function () {
     sandbox.stub(components, 'get');
     sandbox.stub(siteService, 'getSiteFromPrefix');
     sandbox.stub(notifications, 'notify');
+    sandbox.stub(timer);
     sandbox.stub(winston);
+
+    savedTimeoutConstant = lib.getTimeoutConstant();
+    lib.setTimeoutConstant(timeoutConstant);
   });
 
   afterEach(function () {
     sandbox.restore();
+
+    lib.setTimeoutConstant(savedTimeoutConstant);
   });
 
   describe('create', function () {
@@ -131,6 +140,17 @@ describe(_.startCase(filename), function () {
           key: 'domain.com/path/uris/c29tZS1kb21haW4uY29tLw==',
           value: 'domain.com/path/pages/thing'
         });
+      });
+    });
+
+    it('warns if publish is slow', function () {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      notifications.notify.returns(bluebird.resolve());
+      timer.getMillisecondsSince.returns(timeoutConstant * 7);
+
+      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function () {
+        sinon.assert.calledWith(winston.log, 'warn', sinon.match('slow publish domain.com/path/pages/thing@published 700ms'));
       });
     });
 

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports.getMillisecondsSince = function (hrStart) {
+  const diff = process.hrtime(hrStart);
+  
+  return Math.floor((diff[0] * 1e9 + diff[1]) / 1000000);
+};


### PR DESCRIPTION
Patch:
- Log when a particular server.js is slow.
- Fail operation when a particular server.js is twice as slow as that.

This is solving the case where we're not getting an idea of which component is causing a timeout (HTTP 504) on a proxy, so we're going to timeout before them.

Sites can set the timeouts to their own values to increase or decrease what is acceptable.

`require('amphora').components.setTimeoutConstant(10000)` means 
- GET: a component is warned of being slow at 10000ms, and timeouts at 20000ms.
- PUT: a component is warned of being slow at 25000ms, and timeouts at 50000ms.