### PR TITLE
moves addQueryParams from addControllerRoutes to addSites

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -97,7 +97,6 @@ function addControllerRoutes(router) {
     // assume json or text for anything in request bodies
     pathRouter.use(require('body-parser').json({strict: true, type: 'application/json', limit: '50mb'}));
     pathRouter.use(require('body-parser').text({type: 'text/*'}));
-    pathRouter.use(addQueryParams);
 
     controller(pathRouter);
 
@@ -166,6 +165,9 @@ function addSite(router, site) {
   siteRouter.use(addSiteLocals(site));
   siteRouter.use(addAssetDirectory(site));
   siteRouter.use(addCORS(site));
+
+  // add query params to res.locals
+  siteRouter.use(addQueryParams);
 
   // optional module to load routes and configuration defined from outside of amphora
   router.use(path, addSiteController(siteRouter, site));


### PR DESCRIPTION
params need to be added in `addSite` before `addControllerRoutes` in order to expose query params without breaking edits when `req.query.edit` is `true`.