### PR TITLE
PUT @published with empty data

### DIFF
--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -31,11 +31,10 @@ function publishExternally(url) {
     const latest = references.replaceVersion(url),
       published = references.replaceVersion(url, 'published');
 
-    return rest.getObject(latest).then(function (data) {
-      return rest.putObject(published, data);
-    }).then(function () {
-      log('info', 'published', latest);
-    });
+    return rest.putObject(published)
+      .then(function () {
+        log('info', 'published', latest);
+      });
   });
 }
 

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -121,7 +121,6 @@ describe(_.startCase(filename), function () {
         scheduledItem = {at: intervalDelay - 1, publish: uri},
         data = {key:'some-key', value: JSON.stringify(scheduledItem)};
 
-      rest.getObject.returns(bluebird.resolve({}));
       rest.putObject.returns(bluebird.resolve({}));
       siteService.sites.returns([{host: 'a', path: '/'}]);
       db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
@@ -138,25 +137,6 @@ describe(_.startCase(filename), function () {
       };
     });
 
-    it('logs error if missing thing to publish', function (done) {
-      const uri = 'abce/pages/abcd',
-        data = {key:'some-key', value: JSON.stringify({at: intervalDelay - 1, publish: uri})};
-
-      rest.getObject.returns(bluebird.reject(new Error('guess it was not found')));
-      siteService.sites.returns([{host: 'a', path: '/'}]);
-      db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));
-
-      fn();
-
-      sandbox.clock.tick(intervalDelay);
-
-      winston.log = function (logType, msg) {
-        expect(logType).to.equal('error');
-        expect(msg).to.match(/failed to publish/);
-        done();
-      };
-    });
-
     it('logs error if failed to publish page', function (done) {
       bluebird.onPossiblyUnhandledRejection(_.noop);
       // rejection.suppressUnhandledRejections(); when bluebird supports it better
@@ -165,7 +145,6 @@ describe(_.startCase(filename), function () {
         scheduledItem = {at: intervalDelay - 1, publish: uri},
         data = {key:'some-key', value: JSON.stringify(scheduledItem)};
 
-      rest.getObject.returns(bluebird.resolve({}));
       rest.putObject.returns(bluebird.reject(new Error('')));
       siteService.sites.returns([{host: 'a', path: '/'}]);
       db.pipeToPromise.returns(bluebird.resolve(JSON.stringify([data])));


### PR DESCRIPTION
Because of the recent changes to publishing, we can remove some extraneous functionality from the scheduler.

Now it will PUT to `whatever@published` with empty data, rather than fetching the latest data first. This removes some complexity from the scheduler, and has the added bonus of allowing us to schedule the publishing of arbitrary components (which will do a recursive publish of their child components)