### PR TITLE
deny-trailing-slash

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -206,7 +206,7 @@ function notAcceptable(options) {
  */
 function denyTrailingSlashOnId(req, res, next) {
   if (_.last(req.path) === '/') {
-    sendDefaultResponseForCode(400, 'Trailing slash on RESTful id in url is not acceptable', res);
+    sendDefaultResponseForCode(400, 'Trailing slash on RESTful id in URL is not acceptable', res);
   } else {
     next();
   }

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -200,6 +200,19 @@ function notAcceptable(options) {
 }
 
 /**
+ * @param req
+ * @param res
+ * @param {function} next
+ */
+function denyTrailingSlashOnId(req, res, next) {
+  if (_.last(req.path) === '/') {
+    sendDefaultResponseForCode(400, 'Trailing slash on RESTful id in url is not acceptable', res);
+  } else {
+    next();
+  }
+}
+
+/**
  * This route not allowed
  * @returns {function}
  */
@@ -541,6 +554,7 @@ module.exports.serverError = serverError; // bad 500
 // generic handlers
 module.exports.varyWithoutExtension = varyWithoutExtension; // adds Vary header when missing extension
 module.exports.onlyCachePublished = onlyCachePublished; // adds cache control when published or not
+module.exports.denyTrailingSlashOnId = denyTrailingSlashOnId; // nice 400 about not adding trailing slash to id in url
 module.exports.denyReferenceAtRoot = denyReferenceAtRoot; // nice 400 about _ref at root of object
 module.exports.handleError = handleError; // 404 or 500 based on exception
 module.exports.acceptJSONOnly = acceptJSONOnly; // 406 on non-JSON body

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -166,12 +166,14 @@ function routes(router) {
 
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.all('/:name@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', route.get);
   router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@:version', route.put);
 
   router.all('/:name', responses.acceptJSONOnly);
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
+  router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', route.get);
   router.put('/:name', responses.denyReferenceAtRoot);
   router.put('/:name', route.put);
@@ -187,6 +189,7 @@ function routes(router) {
 
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
   router.all('/:name/instances/:id@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name/instances/:id@:version', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id@:version', route.get);
   router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id@published', route.published);
@@ -194,6 +197,7 @@ function routes(router) {
 
   router.all('/:name/instances/:id', responses.acceptJSONOnly);
   router.all('/:name/instances/:id', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
+  router.all('/:name/instances/:id', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id', route.get);
   router.put('/:name/instances/:id', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id', route.put);

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -94,6 +94,7 @@ function routes(router) {
 
   router.all('/:name@:version', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.all('/:name@:version', responses.acceptJSONOnly);
+  router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', responses.getRouteFromDB);
   router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@published', route.putPublish);
@@ -102,6 +103,7 @@ function routes(router) {
 
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.all('/:name', responses.notAcceptable({accept: ['application/json']}));
+  router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', responses.getRouteFromDB);
   router.put('/:name', responses.denyReferenceAtRoot);
   router.put('/:name', responses.putRouteFromDB);

--- a/lib/routes/uris.js
+++ b/lib/routes/uris.js
@@ -48,6 +48,7 @@ function routes(router) {
   router.post('/', responses.notImplemented);
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.all('/:name', responses.notAcceptable({accept: ['text/plain']}));
+  router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', getUriFromReference);
   router.put('/:name', putUriFromReference);
   router.delete('/:name', deleteUriFromReference);

--- a/test/api/components/get.js
+++ b/test/api/components/get.js
@@ -54,7 +54,7 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing'}, 406, message406);
 
       //deny trailing slash
-      acceptsJson(path + '/', {name: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJson(path + '/', {name: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name.json', function () {
@@ -153,7 +153,7 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing', version: 'missing'}, 406);
 
       //deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances', function () {
@@ -195,7 +195,7 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
 
       //deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJson(path + '/', {name: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances/:id.json', function () {
@@ -259,7 +259,7 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', version: 'missing', id: 'missing'}, 406);
 
       //deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', version: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJson(path + '/', {name: 'valid', version: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/components/get.js
+++ b/test/api/components/get.js
@@ -52,6 +52,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid'}, 406, message406);
       acceptsHtml(path, {name: 'missing'}, 406, message406);
+
+      //deny trailing slash
+      acceptsJson(path + '/', {name: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name.json', function () {
@@ -148,6 +151,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'invalid', version: 'missing'}, 404);
       acceptsHtml(path, {name: 'valid', version: 'missing'}, 406);
       acceptsHtml(path, {name: 'missing', version: 'missing'}, 406);
+
+      //deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances', function () {
@@ -187,6 +193,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+
+      //deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances/:id.json', function () {
@@ -248,6 +257,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'invalid', version: 'missing', id: 'valid'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid', version: 'missing', id: 'valid'}, 406);
       acceptsHtml(path, {name: 'valid', version: 'missing', id: 'missing'}, 406);
+
+      //deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', version: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -72,7 +72,7 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
 
       //deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJsonBody(path + '/', {name: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name/schema', function () {
@@ -118,7 +118,7 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
 
       //deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', version}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJsonBody(path + '/', {name: 'valid', version}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances', function () {
@@ -167,7 +167,7 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
 
       //deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances/:id@:version', function () {
@@ -210,7 +210,7 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
 
       //deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', version, id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJsonBody(path + '/', {name: 'valid', version, id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -70,6 +70,9 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      //deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name/schema', function () {
@@ -113,6 +116,9 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      //deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', version}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances', function () {
@@ -159,6 +165,9 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      //deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/components/:name/instances/:id@:version', function () {
@@ -199,6 +208,9 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      //deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', version, id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/pages/get.js
+++ b/test/api/pages/get.js
@@ -122,7 +122,7 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing', version: 'valid'}, 406, '406 text/html not acceptable');
 
       //blocks trailing slash
-      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
 
     describe('/pages/:name@:version.html', function () {

--- a/test/api/pages/get.js
+++ b/test/api/pages/get.js
@@ -120,6 +120,9 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'missing', version: 'missing'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'valid', version: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'missing', version: 'valid'}, 406, '406 text/html not acceptable');
+
+      //blocks trailing slash
+      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
 
     describe('/pages/:name@:version.html', function () {

--- a/test/api/pages/put.js
+++ b/test/api/pages/put.js
@@ -139,7 +139,7 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, pageData), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-      acceptsJsonBody(path + '/', {name: 'valid', version}, pageData, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
+      acceptsJsonBody(path + '/', {name: 'valid', version}, pageData, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/pages/put.js
+++ b/test/api/pages/put.js
@@ -139,6 +139,7 @@ describe(endpointName, function () {
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, pageData), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+      acceptsJsonBody(path + '/', {name: 'valid', version}, pageData, 400, { message: 'Trailing slash on RESTful id in url is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/uris/get.js
+++ b/test/api/uris/get.js
@@ -53,6 +53,9 @@ describe(endpointName, function () {
       acceptsText(path, {name: 'invalid'}, 404, '404 Not Found');
       acceptsText(path, {name: 'valid'}, 200, data);
       acceptsText(path, {name: 'missing'}, 404, '404 Not Found');
+
+      //deny trailing slashes
+      acceptsText(path + '/', {name: 'valid'}, 400, '400 Trailing slash on RESTful id in url is not acceptable');
     });
   });
 });

--- a/test/api/uris/get.js
+++ b/test/api/uris/get.js
@@ -55,7 +55,7 @@ describe(endpointName, function () {
       acceptsText(path, {name: 'missing'}, 404, '404 Not Found');
 
       //deny trailing slashes
-      acceptsText(path + '/', {name: 'valid'}, 400, '400 Trailing slash on RESTful id in url is not acceptable');
+      acceptsText(path + '/', {name: 'valid'}, 400, '400 Trailing slash on RESTful id in URL is not acceptable');
     });
   });
 });

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -63,6 +63,8 @@ describe(endpointName, function () {
       acceptsTextBody(path, {name: 'valid'}, 'localhost.example.com/uris/valid', 400, '400 Cannot point uri at itself');
       // deny uris with quotes
       acceptsTextBody(path, {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Destination cannot contain quotes');
+      // deny trailing slashes
+      acceptsTextBody(path + '/', {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Trailing slash on RESTful id in url is not acceptable');
     });
   });
 });

--- a/test/api/uris/put.js
+++ b/test/api/uris/put.js
@@ -64,7 +64,7 @@ describe(endpointName, function () {
       // deny uris with quotes
       acceptsTextBody(path, {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Destination cannot contain quotes');
       // deny trailing slashes
-      acceptsTextBody(path + '/', {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Trailing slash on RESTful id in url is not acceptable');
+      acceptsTextBody(path + '/', {name: 'valid'}, '"localhost.example.com/uris/valid"', 400, '400 Trailing slash on RESTful id in URL is not acceptable');
     });
   });
 });


### PR DESCRIPTION
Patch
- Explicitly 400 when client tries to PUT or GET from /components/, /pages/, or /uris/ with an id with a trailing slash.

`a/components/b/instances/c/` => `400 Trailing slash on RESTful id in URL is not acceptable`
`a/components/b/instances/c` => `200 Success`