### PR TITLE
allow deletes of versions

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -188,12 +188,13 @@ function routes(router) {
   router.get('/:name/instances/:id.:ext', route.extension);
 
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
-  router.all('/:name/instances/:id@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name/instances/:id@:version', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
   router.all('/:name/instances/:id@:version', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id@:version', route.get);
   router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id@published', route.published);
   router.put('/:name/instances/:id@:version', route.put);
+  router.delete('/:name/instances/:id@:version', route.del);
 
   router.all('/:name/instances/:id', responses.acceptJSONOnly);
   router.all('/:name/instances/:id', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));

--- a/test/api/components/delete.js
+++ b/test/api/components/delete.js
@@ -112,5 +112,23 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', id: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'valid', id: 'missing'}, 406, '406 text/html not acceptable');
     });
+
+    describe('/components/:name/instances/:id@:version', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid@valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid', version: 'valid'}, 404, { message: 'Not Found', code: 404 });
+      acceptsJson(path, {name: 'valid', id: 'valid', version: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid', id: 'missing', version: 'valid'}, 404, { message: 'Not Found', code: 404 });
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid', version: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', id: 'valid', version: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'valid', id: 'missing', version: 'valid'}, 406, '406 text/html not acceptable');
+    });
   });
 });


### PR DESCRIPTION
Allow someone to delete versioned components, like `article/components/abc@published`

This is needed when we want to go back to the state of "this thing has not been published before".