### PR TITLE
allow PUTs to /components/name/instances/id.html

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -22,7 +22,7 @@ const _ = require('lodash'),
  */
 function removePrefix(str, prefixToken) {
   const index =  str.indexOf(prefixToken);
-  
+
   if (index > -1) {
     str = str.substr(index + prefixToken.length).trim();
   }
@@ -36,7 +36,7 @@ function removePrefix(str, prefixToken) {
  */
 function removeExtension(path) {
   let leadingDot, endSlash = path.lastIndexOf('/');
-  
+
   if (endSlash > -1) {
     leadingDot = path.indexOf('.', endSlash);
   } else {
@@ -149,7 +149,7 @@ function sendDefaultResponseForCode(code, message, res, extras) {
 function notImplemented(req, res) {
   const code = 501,
     message = 'Not Implemented';
-  
+
   sendDefaultResponseForCode(code, message, res);
 }
 
@@ -160,7 +160,7 @@ function notImplemented(req, res) {
  */
 function methodNotAllowed(options) {
   const allowed = options.allow;
-  
+
   return function (req, res, next) {
     let message, code,
       method = req.method;
@@ -183,7 +183,7 @@ function methodNotAllowed(options) {
  */
 function notAcceptable(options) {
   const acceptableTypes = options.accept;
-  
+
   return function (req, res, next) {
     let message, code,
       matchedType = req.accepts(acceptableTypes);
@@ -471,7 +471,7 @@ function listWithoutVersions() {
       })];
     }
   };
-  
+
   return list(options);
 }
 
@@ -524,7 +524,7 @@ function putRouteFromDB(req, res) {
  *
  * NOTE: Return the data it used to contain.  This is often used to create queues or messaging on the client-side,
  * because clients can guarantee that only one client was allowed to be the last one to fetch a particular item.
- * 
+ *
  * @param req
  * @param res
  */

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -34,7 +34,7 @@ let validation = _.bindAll({
    */
   componentMustExist(req, res, next) {
     let name = req.params.name;
-    
+
     name = name.split('@')[0];
     name = name.split('.')[0];
 
@@ -116,20 +116,40 @@ let route = _.bindAll({
   },
 
   /**
-   * Change the acceptance type based on the extension they gave us
+   * GET returning html or json depending on extension
    *
    * Fail if they don't accept right protocol and not *
    *
    * @param req
    * @param res
    */
-  extension(req, res) {
+  getExtension(req, res) {
     switch (req.params.ext.toLowerCase()) {
       case 'html':
         return this.render(req, res);
       case 'json': // jshint ignore:line
       default:
         return this.get(req, res);
+    }
+  },
+
+  /**
+   * PUT returning html or json depending on extension
+   * @param req
+   * @param res
+   */
+  putExtension(req, res) {
+    switch (req.params.ext.toLowerCase()) {
+      case 'html':
+        return responses.expectHTML(function () {
+          return controller.put(req.uri, req.body, res.locals)
+            .then(function () {
+              return htmlComposer.renderComponent(req.uri, res, _.pick(req.query, queryStringOptions));
+            });
+        }, res);
+      case 'json': // jshint ignore:line
+      default:
+        return this.put(req, res);
     }
   },
 
@@ -162,7 +182,7 @@ function routes(router) {
 
   router.all('/:name*', validation.componentMustExist);
   router.get('/:name.:ext', responses.onlyAcceptExtensions({extensions: acceptedExtensions}));
-  router.get('/:name.:ext', route.extension);
+  router.get('/:name.:ext', route.getExtension);
 
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.all('/:name@:version', responses.methodNotAllowed({allow: ['get', 'put']}));
@@ -184,8 +204,13 @@ function routes(router) {
   router.get('/:name/instances', responses.listWithoutVersions());
   router.post('/:name/instances', responses.denyReferenceAtRoot);
   router.post('/:name/instances', route.post);
+
+  router.all('/:name/instances/:id.:ext', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.get('/:name/instances/:id.:ext', responses.onlyAcceptExtensions({extensions: acceptedExtensions}));
-  router.get('/:name/instances/:id.:ext', route.extension);
+  router.get('/:name/instances/:id.:ext', route.getExtension);
+  router.put('/:name/instances/:id.:ext', responses.denyReferenceAtRoot);
+  router.put('/:name/instances/:id.:ext', responses.onlyAcceptExtensions({extensions: acceptedExtensions}));
+  router.put('/:name/instances/:id.:ext', route.putExtension);
 
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
   router.all('/:name/instances/:id@:version', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -14,6 +14,7 @@ describe(endpointName, function () {
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      acceptsHtmlBody = apiAccepts.acceptsHtmlBody(_.camelCase(filename)),
       cascades = apiAccepts.cascades(_.camelCase(filename)),
       data = { name: 'Manny', species: 'cat' },
       cascadingTarget = 'localhost.example.com/components/validDeep',
@@ -168,6 +169,69 @@ describe(endpointName, function () {
 
       //deny trailing slashes
       acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/instances/:id.json', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+
+      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+    });
+
+    describe('/components/:name/instances/:id.html', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 406);
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200);
+      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200);
+      acceptsHtmlBody(path, {name: 'missing', id: 'missing'}, data, 200);
+      acceptsHtmlBody(path, {name: 'valid'}, cascadingData(), 200);
+
+      // acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      // acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 406, '<valid>{' +
+      // '"_components":["valid"],' +
+      // '"name":"Manny",' +
+      // '"species":"cat",' +
+      // '"template":"valid",' +
+      // '"_self":"localhost.example.com/components/valid"' +
+      // '}</valid>');
+      // acceptsHtmlBody(path, {name: 'valid', id: 'missing'}, {}, 200, '<valid>{' +
+      // '"_components":["valid"],' +
+      // '"name":"Manny",' +
+      // '"species":"cat",' +
+      // '"template":"valid",' +
+      // '"_self":"localhost.example.com/components/valid"' +
+      // '}</valid>');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
     });
 
     describe('/components/:name/instances/:id@:version', function () {

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -209,26 +209,20 @@ describe(endpointName, function () {
       acceptsJson(path, {name: 'valid', id: 'missing'}, 406);
 
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200);
-      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200);
-      acceptsHtmlBody(path, {name: 'missing', id: 'missing'}, data, 200);
-      acceptsHtmlBody(path, {name: 'valid'}, cascadingData(), 200);
-
-      // acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      // acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 406, '<valid>{' +
-      // '"_components":["valid"],' +
-      // '"name":"Manny",' +
-      // '"species":"cat",' +
-      // '"template":"valid",' +
-      // '"_self":"localhost.example.com/components/valid"' +
-      // '}</valid>');
-      // acceptsHtmlBody(path, {name: 'valid', id: 'missing'}, {}, 200, '<valid>{' +
-      // '"_components":["valid"],' +
-      // '"name":"Manny",' +
-      // '"species":"cat",' +
-      // '"template":"valid",' +
-      // '"_self":"localhost.example.com/components/valid"' +
-      // '}</valid>');
+      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200, '<valid>{' +
+      '"_components":["valid"],' +
+      '"name":"Manny",' +
+      '"species":"cat",' +
+      '"template":"valid",' +
+      '"_self":"localhost.example.com/components/valid/instances/valid"' +
+      '}</valid>');
+      acceptsHtmlBody(path, {name: 'valid', id: 'missing'}, data, 200, '<valid>{' +
+      '"_components":["valid"],' +
+      '"name":"Manny",' +
+      '"species":"cat",' +
+      '"template":"valid",' +
+      '"_self":"localhost.example.com/components/valid/instances/missing"' +
+      '}</valid>');
 
       // block with _ref at root of object
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -68,6 +68,27 @@ function createTest(options) {
 }
 
 /**
+ * Create a generic test that accepts HTML with a BODY
+ * @param method
+ * @returns {Function}
+ */
+function acceptsHtmlBody(method) {
+  return function (path, replacements, body, status, data) {
+    createTest({
+      description: JSON.stringify(replacements) + ' accepts html with body ' + JSON.stringify(body),
+      path,
+      method,
+      replacements,
+      body,
+      data,
+      status,
+      accept: 'text/html',
+      contentType: /html/
+    });
+  };
+}
+
+/**
  * Create a generic test that accepts HTML
  * @param method
  * @returns {Function}
@@ -416,6 +437,7 @@ function beforeEachTest(options) {
 module.exports.setApp = setApp;
 module.exports.setHost = setHost;
 module.exports.acceptsHtml = acceptsHtml;
+module.exports.acceptsHtmlBody = acceptsHtmlBody;
 module.exports.acceptsJson = acceptsJson;
 module.exports.acceptsJsonBody = acceptsJsonBody;
 module.exports.acceptsText = acceptsText;

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -47,7 +47,7 @@ function createTest(options) {
     }
 
     promise = promise
-      .type(options.accept)
+      .type(options.clientType || options.accept) // acceptsHtmlBody sets a different client type
       .set('Accept', options.accept)
       .set('Host', host);
 
@@ -82,8 +82,9 @@ function acceptsHtmlBody(method) {
       body,
       data,
       status,
-      accept: 'text/html',
-      contentType: /html/
+      clientType: 'application/json', // type to send in request
+      accept: 'text/html', // accept header
+      contentType: /html/ // type that should be returned
     });
   };
 }


### PR DESCRIPTION
This allows us to send PUT requests to instances with extensions, e.g. `.json` or `.html`. As with the equivalent GET requests, the extension determines the type of the returned data.

This is useful for Kiln (or other editors) to update components and re-render them without having to do a separate call to grab the rendered HTML after saving.