### PR TITLE
Add CLAY_ACCESS_KEY support for restful calls

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const nodeFetch = require('node-fetch'),
-  jsonHeaders = {'Content-type':'application/json'};
+  jsonHeaders = {'Content-type':'application/json', CLAY_ACCESS_KEY: process.env.CLAY_ACCESS_KEY };
 
 function getObject(url, options) {
   return exports.fetch(url, options).then(function (response) {


### PR DESCRIPTION
Add support to pass access key that clay instances may enforce for some HTTP operations.  Specifically fixes scheduling, where publishes are achieved through a self PUT.  Requires implementation in sites project.