### PR TITLE
simple key mapping for page areas

### DIFF
--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -166,66 +166,20 @@ function refToObj(ref) {
 }
 
 /**
- * Clear and replace original list with items in-place (which may have different length than original)
- *
- * @param {Array} list  Array to clear and replace
- * @param {Array} items  Items to put into the list.
- */
-function replaceItems(list, items) {
-  list.length = 0;
-  list.push.apply(list, items);
-}
-
-/**
- * Takes a component list from the layout data and merges it with data from the page.
- *
- * NOTE: The end result may be longer (or shorter!) than the original list.
- *
- * @param {Array} list
- * @param {object} pageData
- * @returns {array}
- */
-function reducePageDataIntoLayoutComponentList(list, pageData) {
-  return _.reduce(list, function (items, item) {
-    let pageItem;
-
-    // if there is a string, try to find a match
-    if (_.isString(item)) {
-      pageItem = pageData[item];
-
-      if (pageItem) {
-        // if there is a match, assign whatever matches in pageData as a reference
-        if (_.isString(pageItem)) {
-          items.push(refToObj(pageItem));
-        } else if (_.isArray(pageItem)) {
-          items = items.concat(_.map(pageItem, refToObj));
-        } else {
-          // if it's an object or boolean, they're doing something weird
-          log('warn', 'data is not a reference in layout:', item, pageData, list);
-        }
-      } else {
-        // if there is no match, that's a problem with configuration/editing
-        log('warn', 'missing reference in layout:', item, pageData, list);
-      }
-    } else {
-      items.push(item);
-    }
-
-    return items;
-  }, []);
-}
-
-/**
  * Maps strings in arrays of layoutData into the properties of pageData
  * @param {object} pageData
  * @param {object} layoutData
  * @returns {*}
  */
 function mapLayoutToPageData(pageData, layoutData) {
-  const lists = references.listDeepObjects(layoutData, _.isArray);
-
-  _.each(lists, function (list) {
-    replaceItems(list, reducePageDataIntoLayoutComponentList(list, pageData));
+  // quickly (and shallowly) go through the layout's properties,
+  // finding strings that map to page properties
+  _.each(layoutData, function (list, key) {
+    if (_.isString(list) && _.isArray(pageData[key])) {
+      // if you find a match and the data exists,
+      // replace the property in the layout data
+      layoutData[key] = _.map(pageData[key], refToObj);
+    }
   });
 
   return layoutData;

--- a/lib/html-composer.test.js
+++ b/lib/html-composer.test.js
@@ -170,10 +170,10 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('allows arrays in page data with components on either side in layout', function () {
+    it('maps page data into the layout', function () {
       const pageRef = '/pages/whatever',
         layoutRef = '/components/hey',
-        layoutData = {areaA: [{_ref: '/components/c'}, 'head', {_ref: '/components/d'}]},
+        layoutData = {head: 'head', areaA: [{_ref: '/components/c'}, {_ref: '/components/d'}]},
         pageData = {layout: layoutRef, head: ['/components/a', '/components/b']},
         mockComponentData = {whatever: 'whatever'},
         template = '...';
@@ -188,49 +188,18 @@ describe(_.startCase(filename), function () {
       components.getTemplate.returns(template);
 
       return fn(pageRef, getMockRes()).then(function () {
-        const areaA = plex.render.args[0][1].areaA;
+        const head = plex.render.args[0][1].head,
+          areaA = plex.render.args[0][1].areaA;
 
+        expect(head).to.deep.equal([
+          { _ref: '/components/a', whatever: 'whatever' },
+          { _ref: '/components/b', whatever: 'whatever' }
+        ]);
         expect(areaA).to.deep.equal([
           { _ref: '/components/c', whatever: 'whatever' },
-          { _ref: '/components/a', whatever: 'whatever' },
-          { _ref: '/components/b', whatever: 'whatever' },
           { _ref: '/components/d', whatever: 'whatever' }
         ]);
         expectNoLogging();
-      });
-    });
-
-    it('warns if missing reference in layout', function () {
-      const pageRef = '/pages/whatever',
-        layoutRef = '/components/hey',
-        layoutData = {areaA: ['head']},
-        pageData = {layout: layoutRef},
-        template = '...';
-
-      plex.render.returns('<thing></thing>');
-      db.get.withArgs(pageRef).returns(resolveString(pageData));
-      components.get.withArgs(layoutRef).returns(bluebird.resolve(layoutData));
-      components.getTemplate.returns(template);
-
-      return fn(pageRef, getMockRes()).then(function () {
-        sinon.assert.calledWith(winston.log, 'warn');
-      });
-    });
-
-    it('warns if data in page is not a reference', function () {
-      const pageRef = '/pages/whatever',
-        layoutRef = '/components/hey',
-        layoutData = {areaA: ['head']},
-        pageData = {layout: layoutRef, head: {}},
-        template = '...';
-
-      plex.render.returns('<thing></thing>');
-      db.get.withArgs(pageRef).returns(resolveString(pageData));
-      components.get.withArgs(layoutRef).returns(bluebird.resolve(layoutData));
-      components.getTemplate.returns(template);
-
-      return fn(pageRef, getMockRes()).then(function () {
-        sinon.assert.calledWith(winston.log, 'warn');
       });
     });
 

--- a/test/api/pages/get.js
+++ b/test/api/pages/get.js
@@ -12,9 +12,9 @@ describe(endpointName, function () {
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      pageData = { layout: 'localhost.example.com/components/layout', center: 'localhost.example.com/components/valid' },
-      layoutData = { someArea: ['center'] },
-      deepData = { deep: {_ref: 'localhost.example.com/components/validDeep'} },
+      pageData = { layout: 'localhost.example.com/components/layout', center: ['localhost.example.com/components/valid'] },
+      layoutData = { center: 'center', deep: [{_ref: 'localhost.example.com/components/validDeep'}] },
+      deepData = { _ref: 'localhost.example.com/components/validDeep' },
       componentData = { name: 'Manny', species: 'cat' },
       data = {
         page: pageData,
@@ -94,11 +94,11 @@ describe(endpointName, function () {
       acceptsJson(path, {name: 'valid'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/html'] });
       acceptsJson(path, {name: 'missing'}, 406, { message: 'application/json not acceptable', code: 406, accept: ['text/html'] });
       acceptsHtml(path, {name: 'valid'}, 200, '<valid>{' +
-        '"_components":["layout","valid","validDeep"],' +
-        '"someArea":[{"_ref":"localhost.example.com/components/valid","deep":{"_ref":"localhost.example.com/components/validDeep","name":"Manny","species":"cat"}}],' +
+        '"_components":["layout","validDeep","valid"],' +
+        '"center":[{"_ref":"localhost.example.com/components/valid"}],"deep":[{"_ref":"localhost.example.com/components/validDeep","name":"Manny","species":"cat"}],' +
         '"template":"layout",' +
         '"_self":"localhost.example.com/pages/valid",' +
-        '"_pageData":{"center":"localhost.example.com/components/valid"}}</valid>');
+        '"_pageData":{"center":["localhost.example.com/components/valid"]}}</valid>');
       acceptsHtml(path, {name: 'missing'}, 404, '404 Not Found');
     });
 
@@ -148,11 +148,11 @@ describe(endpointName, function () {
       acceptsHtml(path, {name: 'valid', version: 'missing'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'missing', version: 'missing'}, 404, '404 Not Found');
       acceptsHtml(path, {name: 'valid', version: 'valid'}, 200, '<valid>{' +
-        '"_components":["layout","valid","validDeep"],' +
-        '"someArea":[{"_ref":"localhost.example.com/components/valid","deep":{"_ref":"localhost.example.com/components/validDeep","name":"Manny","species":"cat"}}],' +
+        '"_components":["layout","validDeep","valid"],' +
+        '"center":[{"_ref":"localhost.example.com/components/valid"}],"deep":[{"_ref":"localhost.example.com/components/validDeep","name":"Manny","species":"cat"}],' +
         '"template":"layout",' +
         '"_self":"localhost.example.com/pages/valid@valid",' +
-        '"_pageData":{"center":"localhost.example.com/components/valid"},' +
+        '"_pageData":{"center":["localhost.example.com/components/valid"]},' +
         '"_version":"valid"' +
         '}</valid>');
       acceptsHtml(path, {name: 'missing', version: 'valid'}, 404, '404 Not Found');


### PR DESCRIPTION
**BREAKING CHANGE**

This replaces the (complicated) insertion of page data into layouts with a simple 1:1 key mapping. The old way was extremely flexible, but complicated and slow (and it turns out was more than we actually needed). The new way allows us to bake some assumptions into our data and kiln, and lays the foundation for switching layouts.

_Here's what the **old** data looked like:_

```yaml
# page
pageRef:
  layout: /layout/ref
  areaA: /a/string/ref
  areaB:
    - /another/ref
    - /a/third/ref

# layout
layoutRef:
  propA: ['areaA']
  propB:
    -
      _ref: /some/layout/component
    - areaB
```
_Here's what the **new** data looks like:_

```yaml
# page
pageRef:
  layout: /layout/ref
  propA:
    - /a/string/ref # all page areas look the same
  propB:
    - /another/ref
    - /a/third/ref

# layout
layoutRef:
  propA: propA # layout prop and page prop have the same name, allowing for easy insertion and switching
  propB: propB
  propC:
    -
      _ref: /some/layout/component
```