### PR TITLE
301 redirect when uri matches another uri

### DIFF
--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -239,8 +239,8 @@ function renderUri(uri, res) {
     if (route.isUri) {
       let newBase64Uri = _.last(result.split('/')),
         newUri = new Buffer(newBase64Uri, 'base64').toString('utf8'),
-        newPath = url.parse('http://' + newUri).path,
-        newUrl = `http://${res.req.get('host')}${newPath}`;
+        newPath = url.parse(`${res.req.protocol}://${newUri}`).path,
+        newUrl = `${res.req.protocol}://${res.req.get('host')}${newPath}`;
 
       log('info', 'Redirecting to ' + newUrl);
       res.redirect(301, newUrl);

--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -16,6 +16,7 @@ const _ = require('lodash'),
   references = require('./services/references'),
   composer = require('./services/composer'),
   media = require('./media'),
+  url = require('url'),
   defaultHtmlTemplateName = 'template';
 
 /**
@@ -235,7 +236,17 @@ function renderUri(uri, res) {
       throw new Error('Invalid URI: ' + uri + ': ' + result);
     }
 
-    return route.html(result, res);
+    if (route.isUri) {
+      let newBase64Uri = _.last(result.split('/')),
+        newUri = new Buffer(newBase64Uri, 'base64').toString('utf8'),
+        newPath = url.parse('http://' + newUri).path,
+        newUrl = `http://${res.req.get('host')}${newPath}`;
+
+      log('info', 'Redirecting to ' + newUrl);
+      res.redirect(301, newUrl);
+    } else {
+      return route.html(result, res);
+    }
   });
 }
 
@@ -274,13 +285,18 @@ function renderExpressRoute(req, res, next) {
   pageReference = prefix + new Buffer(req.hostname + req.baseUrl + req.path).toString('base64');
 
   renderUri(pageReference, res).then(function (html) {
-    res.type('html');
-    res.send(html);
+    if (html) {
+      // if we're rendering a route normally, there will be html to sent back
+      // if it hits a redirect, there will be nothing here (and we shouldn't try to
+      // send headers after the redirect has fired)
+      res.type('html');
+      res.send(html);
 
-    const diff = process.hrtime(hrStart),
-      ms = Math.floor((diff[0] * 1e9 + diff[1]) / 1000000);
+      const diff = process.hrtime(hrStart),
+        ms = Math.floor((diff[0] * 1e9 + diff[1]) / 1000000);
 
-    log('info', 'rendered express route:' + (req.hostname + req.baseUrl + req.path) + ' ' + ms + 'ms');
+      log('info', 'rendered express route:' + (req.hostname + req.baseUrl + req.path) + ' ' + ms + 'ms');
+    }
   }).catch(function (error) {
     if (error.name === 'NotFoundError') {
       log('verbose', 'in', req.uri, error.message);
@@ -341,6 +357,7 @@ function resetUriRouteHandlers() {
     // uris are not published, they only exist
     {
       when: /\/uris\//,
+      isUri: true,
       html: renderUri,
       json: db.get
     }];

--- a/lib/html-composer.test.js
+++ b/lib/html-composer.test.js
@@ -44,6 +44,7 @@ describe(_.startCase(filename), function () {
 
     // mock this always, sometimes with a fn (don't make actual express calls)
     sandbox.stub(res, 'send', fn);
+    sandbox.stub(res, 'redirect', fn);
 
     return res;
   }
@@ -233,6 +234,18 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('redirects if uri matches another uri', function () {
+      const resultRef = 'domain.com/uris/zxccv',
+        mockRes = getMockRes();
+
+      // when we find the new reference
+      db.get.returns(bluebird.resolve('domain.com/uris/' + new Buffer(resultRef).toString('base64')));
+
+      return fn('/uris/asdf', mockRes).then(function () {
+        expect(mockRes.redirect.callCount).to.equal(1);
+      });
+    });
+
     it('throws if no matching uri route', function (done) {
       const resultRef = 'whatever or something';
 
@@ -285,6 +298,17 @@ describe(_.startCase(filename), function () {
       expectNoLogging();
       done();
     });
+  });
+
+  it('redirects after following uri', function (done) {
+    const res = getMockRes(function () { done(); }),
+      expectedUri = 'example.com/someUrl',
+      expectedOtherUri = 'example.com/someOtherUrl',
+      pathOnBase64 = 'example.com/uris/' + new Buffer(expectedUri).toString('base64');
+
+    db.get.withArgs(pathOnBase64).returns(bluebird.resolve('example.com/uris/' + new Buffer(expectedOtherUri).toString('base64')));
+
+    lib(res.req, res, done.bind(null, 'should not throw'));
   });
 
   it('renders page after following uri', function (done) {

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -129,7 +129,7 @@ Publishing a page has a special convenience behavior where all components refere
 /uris/<base64(:path)>
 ```
 
-A URI is used to redirect some slug or URI to another page or component.  They can also redirect to other uris, or several uris can point to the same resource.  URIs are stored as Base64, so:
+A URI is used to redirect some slug or URI to another page or component.  They can also redirect to other uris (establishing a 301 redirect), or several uris can point to the same resource.  URIs are stored as Base64, so:
 
 - `example.com` is `/uris/ZXhhbXBsZS5jb20=` => `/pages/jdskla@published`
 - `example.com/other/` is `/uris/ZXhhbXBsZS5jb20vb3RoZXI=` => `/pages/4revd3s@published`

--- a/test/fixtures/mocks/res.js
+++ b/test/fixtures/mocks/res.js
@@ -21,6 +21,7 @@ module.exports = function (options) {
   // mock these methods
   res.status = _.constant(res);
   res.send = _.constant(res);
+  res.redirect = _.noop;
   res.json = function (json) {
     res.type('json');
     res.send(json);


### PR DESCRIPTION
When a request comes in for a uri and its data in `/uris/` matches _another_ uri, it will send a 301 redirect rather than recursively looking up uris to serve the page.

From a user's perspective, this will still load the page they were expecting, but the url in their address bar will be the updated url (which corresponds to the uri that points _directly_ to the page).