### PR TITLE
allow oldUrls array in page data

### DIFF
--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -136,8 +136,8 @@ function replacePageReferenceVersions(data, version) {
 
     if (references.isUri(value)) {
       result = replaceVersion(value);
-    } else if (_.isArray(value) && key !== 'oldUrls') {
-      // oldUrls is an array of old page urls. they're not component refs and shouldn't be versioned
+    } else if (_.isArray(value) && key !== 'urlHistory') {
+      // urlHistory is an array of old page urls. they're not component refs and shouldn't be versioned
       result = _.map(value, replaceVersion);
     } else {
       result = value;

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -131,12 +131,13 @@ function applyBatch(site) {
 function replacePageReferenceVersions(data, version) {
   const replaceVersion = _.partial(references.replaceVersion, _, version);
 
-  return _.mapValues(data, function (value) {
+  return _.mapValues(data, function (value, key) {
     let result;
 
     if (references.isUri(value)) {
       result = replaceVersion(value);
-    } else if (_.isArray(value)) {
+    } else if (_.isArray(value) && key !== 'oldUrls') {
+      // oldUrls is an array of old page urls. they're not component refs and shouldn't be versioned
       result = _.map(value, replaceVersion);
     } else {
       result = value;

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -164,7 +164,7 @@ function getUriPrefix(uri) {
  * @returns {object}
  */
 function omitPageConfiguration(pageData) {
-  return _.omit(pageData, ['layout', 'url', 'oldUrls', 'lastModified', 'priority', 'changeFrequency']);
+  return _.omit(pageData, ['layout', 'url', 'urlHistory', 'lastModified', 'priority', 'changeFrequency']);
 }
 
 /**

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -164,7 +164,7 @@ function getUriPrefix(uri) {
  * @returns {object}
  */
 function omitPageConfiguration(pageData) {
-  return _.omit(pageData, ['layout', 'url', 'lastModified', 'priority', 'changeFrequency']);
+  return _.omit(pageData, ['layout', 'url', 'oldUrls', 'lastModified', 'priority', 'changeFrequency']);
 }
 
 /**


### PR DESCRIPTION
Published pages contain the "canonical" url, but they should also store a simple array of _all_ the urls that have been added to it. This allows 3rd party services to easily know when pages have been re-published, and allows us to easily add redirects when re-publishing.

They are listed oldest to newest, like so:

```json
{
  "url": "http://nymag.com/scienceofus/2016/06/new-slug.html",
  "oldUrls": [
    "http://nymag.com/scienceofus/2016/06/old-slug.html",
    "http://nymag.com/scienceofus/2016/06/new-slug.html"
  ]
}
```