### PR TITLE
Allow a site to supply its own chain of responsbility for publishing a page

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -150,7 +150,6 @@ function addSiteController(router, site) {
 
       // things to remember from controller
       _.assign(site, _.pick(controller, 'resolveMedia'));
-      _.assign(site, _.pick(controller, 'publishPage'));
       _.assign(site, _.pick(controller, 'publishingChain'));
     }
   }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -150,7 +150,7 @@ function addSiteController(router, site) {
 
       // things to remember from controller
       _.assign(site, _.pick(controller, 'resolveMedia'));
-      _.assign(site, _.pick(controller, 'publishingChain'));
+      _.assign(site, _.pick(controller, 'resolvePublishing'));
     }
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -150,6 +150,7 @@ function addSiteController(router, site) {
 
       // things to remember from controller
       _.assign(site, _.pick(controller, 'resolveMedia'));
+      _.assign(site, _.pick(controller, 'publishPage'));
     }
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -151,6 +151,7 @@ function addSiteController(router, site) {
       // things to remember from controller
       _.assign(site, _.pick(controller, 'resolveMedia'));
       _.assign(site, _.pick(controller, 'publishPage'));
+      _.assign(site, _.pick(controller, 'publishingChain'));
     }
   }
 

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -242,8 +242,10 @@ function publish(uri, data, locals) {
     prefix = references.getPagePrefix(uri),
     site = getSite(prefix, locals),
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
-
-  return getPublishData(uri, data).then(function (pageData) {
+  return getPublishData(uri, data)
+    .then(function(pageData){
+      return _.isFunction(site.publishPage) ? site.publishPage(uri, pageData, locals) : Promise.resolve(pageData);
+    }).then(function (pageData) {
     const published = 'published',
       publicUrl = pageData.url,
       componentList = references.getPageReferences(pageData);

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -244,7 +244,14 @@ function publish(uri, data, locals) {
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
   return getPublishData(uri, data)
     .then(function(pageData){
-      return _.isFunction(site.publishPage) ? site.publishPage(uri, pageData, locals) : Promise.resolve(pageData);
+      if ( _.isArray(site.publishingChain) ){
+          for (var chainIndex = 0; chainIndex < site.publishingChain.length; chainIndex++ ){
+              if (site.publishingChain[chainIndex].when()){
+                return site.publishingChain[chainIndex].handler(uri, pageData, locals);
+              }
+          }
+      }
+      return Promise.resolve(pageData);
     }).then(function (pageData) {
     const published = 'published',
       publicUrl = pageData.url,

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -246,6 +246,12 @@ function publish(uri, data, locals) {
   return getPublishData(uri, data)
     .then(function (pageData) {
       if ( _.isArray(site.publishingChain) ) {
+        /*
+         * Iterate over an array of publishing functions to find the first one which resolves
+         * This is a variant of the Chain of Responsibility pattern, which we're calling Reject Quickly/Resolve Slowly.
+         * Functions should reject quickly if the data doesn't match the format they want, and afterwards resolve the generated url if the data does match.
+         * The function that resolves is expected to add a `url` property to pageData and return pageData or a promise that resolves to pageData
+         */
         return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
             .then( publishFunction => publishFunction(uri, pageData, locals) )
             .catch( () => pageData );

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -242,7 +242,7 @@ function publish(uri, data, locals) {
     prefix = references.getPagePrefix(uri),
     site = getSite(prefix, locals),
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
-    
+
   /**
    * The publishing chain is an array of functions which either return a function to publish a page
    * or throw an error.  This is a variant of the Chain of Responsibility pattern, which we're calling Reject Quickly/Resolve Slowly.

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -242,24 +242,25 @@ function publish(uri, data, locals) {
     prefix = references.getPagePrefix(uri),
     site = getSite(prefix, locals),
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
+
   return getPublishData(uri, data)
-    .then(function(pageData){
-      if ( _.isArray(site.publishingChain) ){
-          return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
+    .then(function (pageData) {
+      if ( _.isArray(site.publishingChain) ) {
+        return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
             .then( publishFunction => publishFunction(uri, pageData, locals) )
-            .catch( () => pageData )
+            .catch( () => pageData );
       }
       return Promise.resolve(pageData);
     }).then(function (pageData) {
-    const published = 'published',
-      publicUrl = pageData.url,
-      componentList = references.getPageReferences(pageData);
+      const published = 'published',
+        publicUrl = pageData.url,
+        componentList = references.getPageReferences(pageData);
 
-    if (!references.isUrl(publicUrl)) {
-      throw new Error('Client: Page must have valid url to publish.');
-    }
+      if (!references.isUrl(publicUrl)) {
+        throw new Error('Client: Page must have valid url to publish.');
+      }
 
-    return bluebird.map(componentList, getRecursivePublishedPutOperations(locals))
+      return bluebird.map(componentList, getRecursivePublishedPutOperations(locals))
       .then(_.flatten) // only one level of flattening needed, because getPutOperations should have flattened its list already
       .then(function (ops) {
         // convert the data to all @published
@@ -271,13 +272,13 @@ function publish(uri, data, locals) {
         // add page PUT operation last
         return addOp(references.replaceVersion(uri, published), pageData, ops);
       });
-  }).then(applyBatch(site)).tap(function () {
-    const ms = timer.getMillisecondsSince(startTime);
+    }).then(applyBatch(site)).tap(function () {
+      const ms = timer.getMillisecondsSince(startTime);
 
-    if (ms > timeoutLimit * 0.5) {
-      log('warn', 'slow publish', uri, ms + 'ms');
-    }
-  }).timeout(timeoutLimit, 'Page publish exceeded ' + timeoutLimit + 'ms:' + uri);
+      if (ms > timeoutLimit * 0.5) {
+        log('warn', 'slow publish', uri, ms + 'ms');
+      }
+    }).timeout(timeoutLimit, 'Page publish exceeded ' + timeoutLimit + 'ms:' + uri);
 }
 
 /**

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -245,11 +245,8 @@ function publish(uri, data, locals) {
   return getPublishData(uri, data)
     .then(function(pageData){
       if ( _.isArray(site.publishingChain) ){
-          for (var chainIndex = 0; chainIndex < site.publishingChain.length; chainIndex++ ){
-              if (site.publishingChain[chainIndex].when()){
-                return site.publishingChain[chainIndex].handler(uri, pageData, locals);
-              }
-          }
+          return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
+                         .then( publishFunction => publishFunction(uri, pageData, locals) )
       }
       return Promise.resolve(pageData);
     }).then(function (pageData) {

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -242,17 +242,24 @@ function publish(uri, data, locals) {
     prefix = references.getPagePrefix(uri),
     site = getSite(prefix, locals),
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
+    
+  /**
+   * The publishing chain is an array of functions which either return a function to publish a page
+   * or throw an error.  This is a variant of the Chain of Responsibility pattern, which we're calling Reject Quickly/Resolve Slowly.
+   * Functions should reject quickly if the data doesn't match the format they want, and afterwards resolve the generated url if the data does match.
+   * The function that resolves is expected to add a `url` property to pageData and return pageData or a promise that resolves to pageData
+   */
+  let publishingChain = [];
 
+  if (_.isFunction(site.resolvePublishing)) {
+    // Allow a site to add or modify the publishing chain
+    publishingChain = site.resolvePublishing(publishingChain, locals) || publishingChain;
+  }
   return getPublishData(uri, data)
     .then(function (pageData) {
-      if ( _.isArray(site.publishingChain) ) {
-        /*
-         * Iterate over an array of publishing functions to find the first one which resolves
-         * This is a variant of the Chain of Responsibility pattern, which we're calling Reject Quickly/Resolve Slowly.
-         * Functions should reject quickly if the data doesn't match the format they want, and afterwards resolve the generated url if the data does match.
-         * The function that resolves is expected to add a `url` property to pageData and return pageData or a promise that resolves to pageData
-         */
-        return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
+      if ( publishingChain.length > 0 ) {
+         // Iterate over an array of publishing functions to find the first one which resolves
+        return bluebird.any( publishingChain.map( publishingOption => publishingOption(pageData) ) )
             .then( publishFunction => publishFunction(uri, pageData, locals) )
             .catch( () => pageData );
       }

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -246,7 +246,8 @@ function publish(uri, data, locals) {
     .then(function(pageData){
       if ( _.isArray(site.publishingChain) ){
           return bluebird.any( site.publishingChain.map( publishingOption => publishingOption(pageData) ) )
-                         .then( publishFunction => publishFunction(uri, pageData, locals) )
+            .then( publishFunction => publishFunction(uri, pageData, locals) )
+            .catch( () => pageData )
       }
       return Promise.resolve(pageData);
     }).then(function (pageData) {

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -218,11 +218,7 @@ describe(_.startCase(filename), function () {
 
       fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', head: ['']},
         {
-          site: {
-            resolvePublishing: () => [
-              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
-            ]
-          }
+          site: {}
         }).then(done)
         .catch(function (result) {
           expect(result.message).to.equal('Client: page cannot have empty values');

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -131,16 +131,23 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve());
       notifications.notify.returns(bluebird.resolve());
 
-      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function () {
-        const ops = db.batch.args[0][0],
-          secondLastOp = ops[ops.length - 2];
+      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+        }).then(function () {
+          const ops = db.batch.args[0][0],
+            secondLastOp = ops[ops.length - 2];
 
-        expect(secondLastOp).to.deep.equal({
-          type: 'put',
-          key: 'domain.com/path/uris/c29tZS1kb21haW4uY29tLw==',
-          value: 'domain.com/path/pages/thing'
+          expect(secondLastOp).to.deep.equal({
+            type: 'put',
+            key: 'domain.com/path/uris/c29tZS1kb21haW4uY29tLw==',
+            value: 'domain.com/path/pages/thing'
+          });
         });
-      });
     });
 
     it('warns if publish is slow', function () {
@@ -149,9 +156,16 @@ describe(_.startCase(filename), function () {
       notifications.notify.returns(bluebird.resolve());
       timer.getMillisecondsSince.returns(timeoutConstant * 7);
 
-      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function () {
-        sinon.assert.calledWith(winston.log, 'warn', sinon.match('slow publish domain.com/path/pages/thing@published 700ms'));
-      });
+      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+        }).then(function () {
+          sinon.assert.calledWith(winston.log, 'warn', sinon.match('slow publish domain.com/path/pages/thing@published 700ms'));
+        });
     });
 
     it('warns if notification fails', function () {
@@ -163,14 +177,25 @@ describe(_.startCase(filename), function () {
       siteService.getSiteFromPrefix.returns(site);
       notifications.notify.returns(bluebird.reject(new Error('hello!')));
 
-      return fn(uri, {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function () {
-        sinon.assert.calledWith(winston.log, 'warn');
-        sinon.assert.calledOnce(winston.log);
-      });
+      return fn(uri, {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+        }).then(function () {
+          sinon.assert.calledWith(winston.log, 'warn');
+          sinon.assert.calledOnce(winston.log);
+        });
     });
 
     it('notifies', function () {
-      const site = {},
+      const site = {
+          publishingChain: [
+            () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+          ]
+        },
         uri = 'domain.com/path/pages/thing@published';
 
       components.get.returns(bluebird.resolve({}));
@@ -178,9 +203,12 @@ describe(_.startCase(filename), function () {
       siteService.getSiteFromPrefix.returns(site);
       notifications.notify.returns(bluebird.resolve());
 
-      return fn(uri, {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function (result) {
-        sinon.assert.calledWith(notifications.notify, site, 'published', result);
-      });
+      return fn(uri, {layout: 'domain.com/path/components/thing'},
+        {
+          site: site
+        }).then(function (result) {
+          sinon.assert.calledWith(notifications.notify, site, 'published', result);
+        });
     });
 
     it('throws on empty data', function (done) {
@@ -188,8 +216,14 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve());
       siteService.getSiteFromPrefix.returns({notify: _.noop});
 
-      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com', head: ['']})
-        .then(done)
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', head: ['']},
+        {
+          site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+        }).then(done)
         .catch(function (result) {
           expect(result.message).to.equal('Client: page cannot have empty values');
           done();
@@ -202,9 +236,16 @@ describe(_.startCase(filename), function () {
       siteService.getSiteFromPrefix.returns({notify: _.noop});
       notifications.notify.returns(bluebird.resolve());
 
-      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', url: 'http://some-domain.com'}).then(function (result) {
-        expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
-      });
+      return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+        }).then(function (result) {
+          expect(result.layout).to.equal('domain.com/path/components/thing@published');
+        });
     });
 
     it('publishes without provided data', function () {
@@ -214,33 +255,17 @@ describe(_.startCase(filename), function () {
       siteService.getSiteFromPrefix.returns({notify: _.noop});
       notifications.notify.returns(bluebird.resolve());
 
-      return fn('domain.com/path/pages/thing@published').then(function (result) {
-        expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
-      });
+      return fn('domain.com/path/pages/thing@published', {}, {
+        site: {
+            publishingChain: [
+              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+            ]
+          }
+      }).then(function (result) {
+          expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
+        });
     });
 
-    it('throws if missing url with provided data', function (done) {
-      components.get.returns(bluebird.resolve({}));
-      db.batch.returns(bluebird.resolve());
-      siteService.getSiteFromPrefix.returns({notify: _.noop});
-
-      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'}).then(done).catch(function (error) {
-        expect(error).to.be.an.instanceof(Error);
-        done();
-      });
-    });
-
-    it('throws if missing url without provided data', function (done) {
-      components.get.returns(bluebird.resolve({}));
-      db.get.returns(bluebird.resolve(JSON.stringify({layout: 'domain.com/path/components/thing'})));
-      db.batch.returns(bluebird.resolve());
-      siteService.getSiteFromPrefix.returns({notify: _.noop});
-
-      fn('domain.com/path/pages/thing@published').then(done).catch(function (error) {
-        expect(error).to.be.an.instanceof(Error);
-        done();
-      });
-    });
   });
 
   describe('replacePageReferenceVersions', function () {

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -317,7 +317,27 @@ describe(_.startCase(filename), function () {
           done();
         });
     });
+
+    it('throws when the resolvePublishing function exists but does not return an array', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            resolvePublishing: () => undefined
+          }
+        }).then(done)
+            .catch(function (result) {
+              expect(result.message).to.equal('Client: Page must have valid url to publish.');
+              done();
+            });
+    });
   });
+
+
 
   describe('replacePageReferenceVersions', function () {
     const fn = lib[this.title];

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -230,42 +230,6 @@ describe(_.startCase(filename), function () {
         });
     });
 
-    it('throws when a sites publishing chain does not provide a url', function (done) {
-      components.get.returns(bluebird.resolve({}));
-      db.batch.returns(bluebird.resolve());
-      siteService.getSiteFromPrefix.returns({notify: _.noop});
-      notifications.notify.returns(bluebird.resolve());
-
-      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
-        {
-          site: {
-            resolvePublishing: () => [
-              () => function (uri, data) { return data; }
-            ]
-          }
-        }).then(done)
-        .catch(function (result) {
-          expect(result.message).to.equal('Client: Page must have valid url to publish.');
-          done();
-        });
-    });
-
-    it('throws when a site does not provide a resolvePublishing function to modify the publishing chain', function (done) {
-      components.get.returns(bluebird.resolve({}));
-      db.batch.returns(bluebird.resolve());
-      siteService.getSiteFromPrefix.returns({notify: _.noop});
-      notifications.notify.returns(bluebird.resolve());
-
-      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
-        {
-          site: {}
-        }).then(done)
-        .catch(function (result) {
-          expect(result.message).to.equal('Client: Page must have valid url to publish.');
-          done();
-        });
-    });
-
     it('publishes with provided data', function () {
       components.get.returns(bluebird.resolve({}));
       db.batch.returns(bluebird.resolve());
@@ -302,6 +266,41 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('throws when a sites publishing chain does not provide a url', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            resolvePublishing: () => [
+              () => function (uri, data) { return data; }
+            ]
+          }
+        }).then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: Page must have valid url to publish.');
+          done();
+        });
+    });
+
+    it('throws when a site does not provide a resolvePublishing function to modify the publishing chain', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {}
+        }).then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: Page must have valid url to publish.');
+          done();
+        });
+    });
   });
 
   describe('replacePageReferenceVersions', function () {

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -134,7 +134,7 @@ describe(_.startCase(filename), function () {
       return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
         {
           site: {
-            publishingChain: [
+            resolvePublishing: () => [
               () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
             ]
           }
@@ -159,7 +159,7 @@ describe(_.startCase(filename), function () {
       return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
         {
           site: {
-            publishingChain: [
+            resolvePublishing: () => [
               () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
             ]
           }
@@ -180,7 +180,7 @@ describe(_.startCase(filename), function () {
       return fn(uri, {layout: 'domain.com/path/components/thing'},
         {
           site: {
-            publishingChain: [
+            resolvePublishing: () => [
               () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
             ]
           }
@@ -192,7 +192,7 @@ describe(_.startCase(filename), function () {
 
     it('notifies', function () {
       const site = {
-          publishingChain: [
+          resolvePublishing: () => [
             () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
           ]
         },
@@ -219,7 +219,7 @@ describe(_.startCase(filename), function () {
       fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing', head: ['']},
         {
           site: {
-            publishingChain: [
+            resolvePublishing: () => [
               () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
             ]
           }
@@ -239,7 +239,7 @@ describe(_.startCase(filename), function () {
       return fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
         {
           site: {
-            publishingChain: [
+            resolvePublishing: () => [
               () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
             ]
           }
@@ -257,7 +257,7 @@ describe(_.startCase(filename), function () {
 
       return fn('domain.com/path/pages/thing@published', {}, {
         site: {
-          publishingChain: [
+          resolvePublishing: () => [
             () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
           ]
         }

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -286,6 +286,26 @@ describe(_.startCase(filename), function () {
         });
     });
 
+    it('throws when a publishing chain exists but no options ', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            resolvePublishing: () => [
+              () => function () { throw new Error('url error'); }
+            ]
+          }
+        }).then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: Page must have valid url to publish.');
+          done();
+        });
+    });
+
     it('throws when a site does not provide a resolvePublishing function to modify the publishing chain', function (done) {
       components.get.returns(bluebird.resolve({}));
       db.batch.returns(bluebird.resolve());

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -230,6 +230,42 @@ describe(_.startCase(filename), function () {
         });
     });
 
+    it('throws when a sites publishing chain does not provide a url', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {
+            resolvePublishing: () => [
+              () => function (uri, data) { return data; }
+            ]
+          }
+        }).then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: Page must have valid url to publish.');
+          done();
+        });
+    });
+
+    it('throws when a site does not provide a resolvePublishing function to modify the publishing chain', function (done) {
+      components.get.returns(bluebird.resolve({}));
+      db.batch.returns(bluebird.resolve());
+      siteService.getSiteFromPrefix.returns({notify: _.noop});
+      notifications.notify.returns(bluebird.resolve());
+
+      fn('domain.com/path/pages/thing@published', {layout: 'domain.com/path/components/thing'},
+        {
+          site: {}
+        }).then(done)
+        .catch(function (result) {
+          expect(result.message).to.equal('Client: Page must have valid url to publish.');
+          done();
+        });
+    });
+
     it('publishes with provided data', function () {
       components.get.returns(bluebird.resolve({}));
       db.batch.returns(bluebird.resolve());

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -257,13 +257,13 @@ describe(_.startCase(filename), function () {
 
       return fn('domain.com/path/pages/thing@published', {}, {
         site: {
-            publishingChain: [
-              () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
-            ]
-          }
+          publishingChain: [
+            () => function (uri, data) { data.url = 'http://some-domain.com'; return data; }
+          ]
+        }
       }).then(function (result) {
-          expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
-        });
+        expect(result).to.deep.equal({layout: 'domain.com/path/components/thing@published', url: 'http://some-domain.com'});
+      });
     });
 
   });


### PR DESCRIPTION
This is work in advance of allowing each site to custom define its own url structure.  This allows each site to supply its own hierarchy of rules to determine what url to generate when publishing a page. 

You can observe the changes to our implentation that will be required with this update here at: https://github.com/nymag/sites/pull/1236