### PR TITLE
Page layout default value

### DIFF
--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -176,10 +176,16 @@ function mapLayoutToPageData(pageData, layoutData) {
   // quickly (and shallowly) go through the layout's properties,
   // finding strings that map to page properties
   _.each(layoutData, function (list, key) {
-    if (_.isString(list) && _.isArray(pageData[key])) {
-      // if you find a match and the data exists,
-      // replace the property in the layout data
-      layoutData[key] = _.map(pageData[key], refToObj);
+    if (_.isString(list)) {
+      if ( _.isArray(pageData[key])) {
+        // if you find a match and the data exists,
+        // replace the property in the layout data
+        layoutData[key] = _.map(pageData[key], refToObj);
+      } else {
+        // otherwise replace it with an empty list
+        // as all layout properties are component lists
+        layoutData[key] = [];
+      }
     }
   });
 

--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -390,3 +390,5 @@ module.exports.addEngines = addEngines;
 // for testing (or maybe from a config later?)
 module.exports.setUriRouteHandlers = setUriRouteHandlers;
 module.exports.resetUriRouteHandlers = resetUriRouteHandlers;
+module.exports.mapLayoutToPageData = mapLayoutToPageData;
+module.exports.refToObj = refToObj;

--- a/lib/html-composer.test.js
+++ b/lib/html-composer.test.js
@@ -380,7 +380,7 @@ describe(_.startCase(filename), function () {
   describe('refToObj', function () {
     const fn = lib[this.title];
 
-    it('wraps an object with', function () {
+    it('sets data to be the value of an object with key "_ref"', function () {
       const data = { key: 'value'},
         expectedResultData =  { _ref: data },
         newData = fn(data);

--- a/lib/html-composer.test.js
+++ b/lib/html-composer.test.js
@@ -204,6 +204,8 @@ describe(_.startCase(filename), function () {
       });
     });
 
+
+
     it('throws if edit mode and it has a version', function () {
       expect(function () {
         fn('/components/thing@some-version', {req: {query: {edit: true}}});
@@ -373,5 +375,49 @@ describe(_.startCase(filename), function () {
     plex.render.returns('<thing></thing>');
 
     lib(res.req, res, done);
+  });
+
+  describe('refToObj', function () {
+    const fn = lib[this.title];
+
+    it('wraps an object with', function () {
+      const data = { key: 'value'},
+        expectedResultData =  { _ref: data },
+        newData = fn(data);
+
+      expect(newData).to.deep.equal(expectedResultData);
+    });
+  });
+
+  describe('mapLayoutToPageData', function () {
+    const fn = lib[this.title];
+
+    it('replaces references from layout data with page data', function () {
+      const pageData = {
+          main: [{ key: 'value'}]
+        },
+        layoutData = {
+          main: 'main'
+        },
+        expectedResultData = {
+          main: [lib.refToObj({ key: 'value'})]
+        },
+        newData = fn(pageData, layoutData);
+
+      expect(newData).to.deep.equal(expectedResultData);
+    });
+
+    it('replaces missing references with []', function () {
+      const pageData = {},
+        layoutData = {
+          main: 'main'
+        },
+        expectedResultData = {
+          main: []
+        },
+        newData = fn(pageData, layoutData);
+
+      expect(newData).to.deep.equal(expectedResultData);
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "An API mixin for Express that saves, publishes and composes data with the key-value store of your choice.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/eslint --max-warnings 0 lib test && node_modules/.bin/istanbul cover node_modules/.bin/_mocha"
+    "test": "npm run eslint && npm run test-suite",
+    "eslint": "eslint --max-warnings 0 lib test",
+    "test-suite": "istanbul cover mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run eslint && npm run test-suite",
     "eslint": "eslint --max-warnings 0 lib test",
-    "test-suite": "istanbul cover mocha"
+    "test-suite": "istanbul cover _mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently in layouts, you are allowed to use strings as keys to layout properties that are meant to reference properties of the page. For instance: "main", "minor", "splashHeader".

Currently, if it has a string value and it can't find a match in page's keys, it will leave the value as is, as a string.  Now, it will be replaced by an empty array.  All layout properties currently are componentLists, so we should replace with an empty list so we can do things like check main.length.  Previously, you would have gotten a false positive if you hadn't defined "main" in page data, as "main".length === 4, so it would evaluate truthily.