### PR TITLE
add available routes to locals

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -60,6 +60,24 @@ function addQueryParams(req, res, next) {
 }
 
 /**
+ * add available site routes to locals
+ * @param {express.Router} router
+ * @returns {function}
+ */
+function addAvailableRoutes(router) {
+  return function (req, res, next) {
+    var routes = _(router.stack)
+      .filter((r) => r.route && r.route.path) // grab only the defined routes (not api stuff)
+      .map((r) => r.route.path) // pull out their paths
+      .reject((r) => _.includes(['/sitemap.txt', '/sitemap.xml'], r)) // filter out sitemaps
+      .value();
+
+    res.locals.routes = routes; // and add them to the locals
+    next();
+  };
+}
+
+/**
  * @param {object} req
  * @param {object} res
  * @param {function} next
@@ -174,6 +192,9 @@ function addSite(router, site) {
   // add query params to res.locals
   siteRouter.use(addQueryParams);
 
+  // add available routes to locals
+  siteRouter.use(addAvailableRoutes(siteRouter));
+
   // optional module to load routes and configuration defined from outside of amphora
   router.use(path, addSiteController(siteRouter, site));
 
@@ -285,4 +306,5 @@ module.exports.addHost = addHost;
 module.exports.getDefaultSiteSettings = getDefaultSiteSettings;
 module.exports.sortByDepthOfPath = sortByDepthOfPath;
 module.exports.addCORS = addCORS;
+module.exports.addAvailableRoutes = addAvailableRoutes;
 module.exports.addSiteController = addSiteController;

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -62,6 +62,70 @@ describe(_.startCase(filename), function () {
     });
   });
 
+  describe('addAvailableRoutes', function () {
+    const fn = lib[this.title];
+
+    it('adds no routes if no routes defined', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal([]);
+      }
+
+      fn({ stack: [] })({}, res, checkRoutes);
+    });
+
+    it('adds no routes if no routes have route properties', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal([]);
+      }
+
+      fn({ stack: [{}] })({}, res, checkRoutes);
+    });
+
+    it('adds no routes if no routes have paths', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal([]);
+      }
+
+      fn({ stack: [{ route: {} }] })({}, res, checkRoutes);
+    });
+
+    it('adds routes to locals', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal(['/foo']);
+      }
+
+      fn({ stack: [{ route: { path: '/foo' }}] })({}, res, checkRoutes);
+    });
+
+    it('does not add sitemap txt route', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal([]);
+      }
+
+      fn({ stack: [{ route: { path: '/sitemap.txt' }}] })({}, res, checkRoutes);
+    });
+
+    it('does not add sitemap xml route', function () {
+      let res = { locals: {} };
+
+      function checkRoutes() {
+        expect(res.locals.routes).to.deep.equal([]);
+      }
+
+      fn({ stack: [{ route: { path: '/sitemap.xml' }}] })({}, res, checkRoutes);
+    });
+  });
+
   describe('sortByDepthOfPath', function () {
     const fn = lib[this.title];
 


### PR DESCRIPTION
this is useful for things like [url validation](https://trello.com/c/4bXk7e7o/10-validate-custom-urls-kiln) on the client-side, as components like kiln would need a list of the available routes for a site.

it exposes an array of the paths in `res.locals.routes`, e.g. `['/', '/:name']`