### PR TITLE
switch to hostname from host on redirect

### DIFF
--- a/lib/html-composer.js
+++ b/lib/html-composer.js
@@ -246,7 +246,7 @@ function renderUri(uri, res) {
       let newBase64Uri = _.last(result.split('/')),
         newUri = new Buffer(newBase64Uri, 'base64').toString('utf8'),
         newPath = url.parse(`${res.req.protocol}://${newUri}`).path,
-        newUrl = `${res.req.protocol}://${res.req.get('host')}${newPath}`;
+        newUrl = `${res.req.protocol}://${res.req.hostname}${newPath}`;
 
       log('info', 'Redirecting to ' + newUrl);
       res.redirect(301, newUrl);


### PR DESCRIPTION
When using express 'trust proxy' setting req.hostname pulls first from X-Forwarded-Host instead of Host header. If X-Forwarded-Host does not exist, it falls back to Host header (e.g. for local development).