### PR TITLE
add available components to locals

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -78,6 +78,17 @@ function addAvailableRoutes(router) {
 }
 
 /**
+ * add available components to locals
+ * @param {req} req
+ * @param {res} res
+ * @param {function} next
+ */
+function addAvailableComponents(req, res, next) {
+  res.locals.components = files.getComponents();
+  next();
+}
+
+/**
  * @param {object} req
  * @param {object} res
  * @param {function} next
@@ -195,6 +206,9 @@ function addSite(router, site) {
   // add available routes to locals
   siteRouter.use(addAvailableRoutes(siteRouter));
 
+  // add available components to locals
+  siteRouter.use(addAvailableComponents);
+
   // optional module to load routes and configuration defined from outside of amphora
   router.use(path, addSiteController(siteRouter, site));
 
@@ -307,4 +321,5 @@ module.exports.getDefaultSiteSettings = getDefaultSiteSettings;
 module.exports.sortByDepthOfPath = sortByDepthOfPath;
 module.exports.addCORS = addCORS;
 module.exports.addAvailableRoutes = addAvailableRoutes;
+module.exports.addAvailableComponents = addAvailableComponents;
 module.exports.addSiteController = addSiteController;

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -126,6 +126,22 @@ describe(_.startCase(filename), function () {
     });
   });
 
+  describe('addAvailableComponents', function () {
+    const fn = lib[this.title];
+
+    it('adds available components to locals', function () {
+      let res = { locals: {} };
+
+      sandbox.stub(files, 'getComponents').returns(['foo', 'bar']);
+
+      function checkComponents() {
+        expect(res.locals.components).to.deep.equal(['foo', 'bar']);
+      }
+
+      fn({}, res, checkComponents);
+    });
+  });
+
   describe('sortByDepthOfPath', function () {
     const fn = lib[this.title];
 
@@ -170,6 +186,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'fileExists');
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getFiles');
+      sandbox.stub(files, 'getComponents');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
@@ -189,6 +206,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
       sandbox.stub(files, 'tryRequire');
+      sandbox.stub(files, 'getComponents');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
@@ -209,6 +227,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(express, 'Router', _.constant(innerRouter));
       sandbox.stub(files, 'fileExists');
       sandbox.stub(files, 'tryRequire');
+      sandbox.stub(files, 'getComponents');
       sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(false);


### PR DESCRIPTION
adds all available components to locals. this is useful for kiln to know what components are available on a specific clay install, since a layout's _components array is actually just an array of the components that currently exist in that layout.