### PR TITLE
log errors when component modules error out

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -15,6 +15,7 @@ let _ = require('lodash'),
   yaml = require('js-yaml'),
   pkg = require(path.resolve('package.json')),
   temp2env = require('template2env'),
+  log = require('./services/log').withStandardPrefix(__filename),
   req = require,
   allowedEnvFiles = ['local', 'config'];
 
@@ -175,6 +176,7 @@ function tryRequire(filePath) {
     result = req(filePath);
   } catch (ex) {
     if (ex.message && !ex.message.match(/Cannot find module/i)) {
+      log('error', `Failed to load ${filePath}: ${ex.message}`);
       throw ex;
     }
   }

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -10,6 +10,7 @@ const _ = require('lodash'),
   glob = require('glob'),
   lib = require('./' + filename),
   pkg = require('../test/fixtures/config/package.json'),
+  log = require('./services/log'),
   temp2env = require('template2env');
 
 describe(_.startCase(filename), function () {
@@ -29,6 +30,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(fs, 'readFileSync');
     sandbox.stub(path, 'resolve');
     sandbox.stub(yaml);
+    sandbox.stub(log);
     sandbox.stub(glob, 'sync');
     sandbox.stub(temp2env);
 


### PR DESCRIPTION
this will log errors when component modules error out (and the error isn't just that the module cannot be found)

this fixes most of the issues we've had with eaten logs

_note:_ this won't log when a component module requires another module that doesn't exist (but it will log if that other module exists but throws a different error)

[trello ticket](https://trello.com/c/7mKVZwPI/44-better-silly-logging-when-clay-404-s)