### PR TITLE
added /users route

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -112,7 +112,8 @@ function addUri(req, res, next) {
 }
 
 /**
- * Add component routes to this router.
+ * Add route controllers to this router.
+ * Note: This adds all controllers defined in lib/routes/
  * @param {express.Router} router
  */
 function addControllerRoutes(router) {

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -11,6 +11,7 @@ For a broader and less specific overview of routing, please see the [project's r
 - [Pages](#pages)
 - [URIs](#uris)
 - [Lists](#lists)
+- [Users](#users)
 - [Schedule](#schedule)
 - [Versions](#versions)
 - [RESTful API](#restful-api)
@@ -144,6 +145,16 @@ A URI is assumed to be pointing at the `@published` version if another version i
 ```
 
 Lists are a _temporary_ solution until search functionality is discussed.  It is currently used for the tags component and the autocomplete behavior as a temporary place to store lists of information.  It can store any list of data on a `PUT`, and return back the same list of data with a `GET`.
+
+## Users
+
+### Overview
+```
+/users
+/users/:id
+```
+
+Each user has a `username` and `provider`, which determines how they authenticate over oauth. Users can also have other data, including `name`, `imageUrl`, and `title`.
 
 ## Schedule
 

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -1,0 +1,56 @@
+/**
+ * Controller for Users
+ *
+ * @module
+ */
+
+'use strict';
+
+const _ = require('lodash'),
+  responses = require('../responses'),
+  controller = require('../services/users');
+
+/**
+ * All routes go here.
+ *
+ * They will all have the form (req, res), but never with next()
+ *
+ * @namespace
+ */
+let route = _.bindAll({
+  /**
+   * @param {object} req
+   * @param {object} res
+   */
+  post(req, res) {
+    responses.expectJSON(function () {
+      return controller.post(req.uri, req.body, res.locals);
+    }, res);
+  }
+}, [
+  'post'
+]);
+
+function routes(router) {
+  router.use(responses.varyWithoutExtension({varyBy: ['Accept']}));
+
+  // list users
+  router.all('/', responses.methodNotAllowed({allow: ['get', 'post']}));
+  router.all('/', responses.notAcceptable({accept: ['application/json']}));
+  router.get('/', responses.list());
+
+  // create new user
+  router.post('/', responses.denyReferenceAtRoot);
+  router.post('/', route.post);
+
+  // get and update users
+  router.all('/:name', responses.acceptJSONOnly);
+  router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
+  router.all('/:name', responses.denyTrailingSlashOnId);
+  router.put('/:name', responses.denyReferenceAtRoot);
+  router.get('/:name', responses.getRouteFromDB);
+  router.put('/:name', responses.putRouteFromDB);
+  router.delete('/:id', responses.deleteRouteFromDB);
+}
+
+module.exports = routes;

--- a/lib/services/users.js
+++ b/lib/services/users.js
@@ -1,0 +1,27 @@
+/**
+ * Controller for Users
+ *
+ * @module
+ */
+
+'use strict';
+
+const db = require('./db'),
+  uid = require('../uid');
+
+/**
+ * @param {string} uri
+ * @param {object} data
+ * @returns {Promise}
+ */
+function post(uri, data) {
+  uri += '/' + uid.get();
+
+  return db.put(uri, JSON.stringify(data)).then(function () {
+    data._ref = uri;
+    return data;
+  });
+}
+
+// outsiders can act on users
+module.exports.post = post;

--- a/lib/services/users.test.js
+++ b/lib/services/users.test.js
@@ -1,0 +1,44 @@
+'use strict';
+const _ = require('lodash'),
+  bluebird = require('bluebird'),
+  db = require('./db'),
+  uid = require('../uid'),
+  filename = __filename.split('/').pop().split('.').shift(),
+  expect = require('chai').expect,
+  sinon = require('sinon'),
+  lib = require('./' + filename),
+  fakeUID = 'a1b2c3',
+  baseUri = 'domain.com/users',
+  uri = baseUri + '/' + fakeUID;
+
+describe(_.startCase(filename), function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(uid, 'get').returns(fakeUID);
+    sandbox.stub(db, 'put');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('post', function () {
+    const fn = lib[this.title];
+
+    it('creates a user', function () {
+      const data = {
+        username: 'bar',
+        provider: 'twitter'
+      };
+
+      db.put.returns(bluebird.resolve());
+
+      return fn(baseUri, _.clone(data)).then(function (result) {
+        expect(db.put.calledWith(uri, JSON.stringify(data))).to.equal(true);
+        expect(result).to.deep.equal(_.assign(data, { _ref: uri }));
+      });
+    });
+  });
+});

--- a/test/api/users/delete.js
+++ b/test/api/users/delete.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    let sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      data = { name: 'Manny', species: 'cat' };
+
+    before(function () {
+      sandbox = sinon.sandbox.create();
+      this.timeout(500);
+      return apiAccepts.beforeTesting(this, {
+        hostname,
+        data,
+        sandbox
+      }).then(function () {
+        sandbox.restore();
+      });
+    });
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/users', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method DELETE not allowed' });
+      acceptsHtml(path, {}, 405, '405 Method DELETE not allowed');
+    });
+
+    describe('/users/:name', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/users/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404, { message: 'Not Found', code: 404 });
+      acceptsJson(path, {name: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'missing'}, 404, { message: 'Not Found', code: 404 });
+
+      acceptsHtml(path, {name: 'invalid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+    });
+  });
+});

--- a/test/api/users/get.js
+++ b/test/api/users/get.js
@@ -1,0 +1,265 @@
+'use strict';
+
+const _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    let sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      data = { name: 'Manny', species: 'cat' },
+      // todo: Stop putting internal information into something we're going to open-source
+      componentList = ['clay-c5', 'clay-c3', 'clay-c4'],
+      message406 = '406 text/html not acceptable';
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/components', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {}, 200, componentList);
+      acceptsHtml(path, {}, 406, message406);
+    });
+
+    describe('/components/:name', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406, message406);
+      acceptsHtml(path, {name: 'missing'}, 406, message406);
+
+      // deny trailing slash
+      acceptsJson(path + '/', {name: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name.json', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406, message406);
+      acceptsHtml(path, {name: 'missing'}, 406, message406);
+    });
+
+    describe('/components/:name/schema', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 200, {some:'schema', thatIs:'valid'});
+      acceptsJson(path, {name: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406, message406);
+      acceptsHtml(path, {name: 'missing'}, 406, message406);
+    });
+
+    describe('/components/:name.html', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
+      acceptsJson(path, {name: 'missing'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 200,
+        '<valid>{' +
+        '"_components":["valid"],' +
+        '"name":"Manny",' +
+        '"species":"cat",' +
+        '"template":"valid",' +
+        '"_self":"localhost.example.com/components/valid"' +
+        '}</valid>');
+      acceptsHtml(path, {name: 'missing'}, 404, '404 Not Found');
+    });
+
+    describe('/components/:name.bad', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 404, '{"message":"Not Found","code":404}');
+      acceptsJson(path, {name: 'missing'}, 404, '{"message":"Not Found","code":404}');
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'missing'}, 404, '404 Not Found');
+    });
+
+    describe('/components/:name@:version', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid@valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', version: 'missing'}, 404);
+      acceptsJson(path, {name: 'valid', version: 'missing'}, 404);
+      acceptsJson(path, {name: 'valid', version: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'missing', version: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid', version: 'missing'}, 404);
+      acceptsHtml(path, {name: 'valid', version: 'missing'}, 406);
+      acceptsHtml(path, {name: 'missing', version: 'missing'}, 406);
+
+      // deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/instances', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid': data,
+          '/components/valid/instances/valid': data,
+          '/components/valid/instances/valid@valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      // no versioned or base instances in list
+      acceptsJson(path, {name: 'valid'}, 200, '["localhost.example.com/components/valid/instances/valid"]');
+      acceptsJson(path, {name: 'missing'}, 200, '[]');
+
+      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid'}, 406);
+      acceptsHtml(path, {name: 'missing'}, 406);
+    });
+
+    describe('/components/:name/instances/:id', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+
+      // deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/instances/:id.json', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+    });
+
+    describe('/components/:name/instances/:id.html', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 200, '<valid>{' +
+        '"_components":["valid"],' +
+        '"name":"Manny",' +
+        '"species":"cat",' +
+        '"template":"valid",' +
+        '"_self":"localhost.example.com/components/valid/instances/valid"' +
+        '}</valid>');
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 404, '404 Not Found');
+    });
+
+    describe('/components/:name/instances/:id@:version', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid@valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', version: 'missing', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'valid', version: 'valid', id: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid', version: 'missing', id: 'valid'}, 404);
+      acceptsJson(path, {name: 'valid', version: 'missing', id: 'missing'}, 404);
+
+      acceptsHtml(path, {name: 'invalid', version: 'missing', id: 'valid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'valid', version: 'missing', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', version: 'missing', id: 'missing'}, 406);
+
+      // deny trailing slash
+      acceptsJson(path + '/', {name: 'valid', version: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+  });
+});

--- a/test/api/users/post.js
+++ b/test/api/users/post.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    let sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      expectDataPlusRef = apiAccepts.expectDataPlusRef,
+      data = { name: 'Manny', species: 'cat' };
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/users', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname  });
+      });
+
+      acceptsJson(path, {name: 'valid'}, 200, expectDataPlusRef({}));
+      acceptsJson(path, {name: 'missing'}, 200, expectDataPlusRef({}));
+
+      acceptsJsonBody(path, {name: 'valid'}, data, 200, expectDataPlusRef(data));
+      acceptsJsonBody(path, {name: 'missing'}, data, 200, expectDataPlusRef(data));
+
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+    });
+
+    describe('/users/:name', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname  });
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
+      acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'put', 'delete'], code: 405, message: 'Method POST not allowed' });
+
+      acceptsHtml(path, {name: 'invalid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
+      acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');
+    });
+  });
+});

--- a/test/api/users/put.js
+++ b/test/api/users/put.js
@@ -1,0 +1,274 @@
+'use strict';
+
+const _ = require('lodash'),
+  apiAccepts = require('../../fixtures/api-accepts'),
+  endpointName = _.startCase(__dirname.split('/').pop()),
+  filename = _.startCase(__filename.split('/').pop().split('.').shift()),
+  replaceVersion = require('../../../lib/services/references').replaceVersion,
+  sinon = require('sinon');
+
+describe(endpointName, function () {
+  describe(filename, function () {
+    let sandbox,
+      hostname = 'localhost.example.com',
+      acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
+      acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
+      acceptsHtmlBody = apiAccepts.acceptsHtmlBody(_.camelCase(filename)),
+      cascades = apiAccepts.cascades(_.camelCase(filename)),
+      data = { name: 'Manny', species: 'cat' },
+      cascadingTarget = 'localhost.example.com/components/validDeep',
+      addVersion = _.partial(replaceVersion, cascadingTarget),
+      cascadingData = function (version) {
+        return {a: 'b', c: {_ref: addVersion(version), d: 'e'}};
+      },
+      cascadingReturnData = function (version) {
+        return {a: 'b', c: {_ref: addVersion(version)}};
+      },
+      cascadingDeepData = {d: 'e'};
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('/components', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {}, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsHtml(path, {}, 405);
+    });
+
+    describe('/components/:name', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'missing'}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid'}, 404);
+      acceptsHtml(path, {name: 'valid'}, 406);
+      acceptsHtml(path, {name: 'missing'}, 406);
+
+      cascades(path, {name: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      // deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/schema', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404);
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+
+      acceptsHtml(path, {name: 'invalid'}, 404);
+      acceptsHtml(path, {name: 'valid'}, 405);
+      acceptsHtml(path, {name: 'missing'}, 405);
+    });
+
+    describe('/components/:name@:version', function () {
+      const path = this.title,
+        version = 'def';
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', version}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', version}, 200, {});
+      acceptsJson(path, {name: 'missing', version}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid', version}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', version}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', version}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid', version}, 404);
+      acceptsHtml(path, {name: 'valid', version}, 406);
+      acceptsHtml(path, {name: 'missing', version}, 406);
+
+      cascades(path, {name: 'valid', version}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      // deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', version}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/instances', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+
+      acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {name: 'missing'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+
+      acceptsHtml(path, {name: 'invalid'}, 404);
+      acceptsHtml(path, {name: 'valid'}, 406);
+      acceptsHtml(path, {name: 'missing'}, 406);
+    });
+
+    describe('/components/:name/instances/:id', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+
+      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      // deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+
+    describe('/components/:name/instances/:id.json', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
+
+      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+    });
+
+    describe('/components/:name/instances/:id.html', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 406);
+      acceptsJson(path, {name: 'valid', id: 'missing'}, 406);
+
+      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
+      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200, '<valid>{' +
+      '"_components":["valid"],' +
+      '"name":"Manny",' +
+      '"species":"cat",' +
+      '"template":"valid",' +
+      '"_self":"localhost.example.com/components/valid/instances/valid"' +
+      '}</valid>');
+      acceptsHtmlBody(path, {name: 'valid', id: 'missing'}, data, 200, '<valid>{' +
+      '"_components":["valid"],' +
+      '"name":"Manny",' +
+      '"species":"cat",' +
+      '"template":"valid",' +
+      '"_self":"localhost.example.com/components/valid/instances/missing"' +
+      '}</valid>');
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+    });
+
+    describe('/components/:name/instances/:id@:version', function () {
+      let path = this.title,
+        version = 'def';
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/valid/instances/valid': data
+        }});
+      });
+
+      acceptsJson(path, {name: 'invalid', version, id: 'valid'}, 404, { code: 404, message: 'Not Found' });
+      acceptsJson(path, {name: 'valid', version, id: 'valid'}, 200, {});
+      acceptsJson(path, {name: 'valid', version, id: 'missing'}, 200, {});
+
+      acceptsJsonBody(path, {name: 'invalid', version, id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'missing', version, id: 'missing'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, cascadingData(), 200, cascadingReturnData());
+
+      acceptsHtml(path, {name: 'invalid', version, id: 'valid'}, 404);
+      acceptsHtml(path, {name: 'valid', version, id: 'valid'}, 406);
+      acceptsHtml(path, {name: 'valid', version, id: 'missing'}, 406);
+
+      cascades(path, {name: 'valid', version, id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
+
+      // published version
+      version = 'published';
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, data, 200, data);
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
+      cascades(path, {name: 'valid', version, id: 'valid'}, cascadingData(version), addVersion(version), cascadingDeepData);
+
+      // published blank data will publish @latest
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, {}, 200, data);
+      // publishing blank data without a @latest will 404 because missing resource
+      acceptsJsonBody(path, {name: 'valid', version, id: 'missing'}, {}, 404, { code: 404, message: 'Not Found' });
+
+      // block with _ref at root of object
+      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
+
+      // deny trailing slashes
+      acceptsJsonBody(path + '/', {name: 'valid', version, id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
+    });
+  });
+});


### PR DESCRIPTION
Two new routes!

* `/users` lists all users in a site, and allows creating new users
* `/users:name` gives data for an individual user, and allows updating and deleting individual users

Notes:

* `:name` is the automatically-generated ID you get when creating a user. Uses the same UID generator as component instance IDs.
* After this I'll start adding oauth stuff that uses the user data