### PR TITLE
Return an error message if we have one

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -327,7 +327,7 @@ function serverError(err, res) {
   // error is required to be logged
   log('error', err);
 
-  const message = 'Server Error', // completely hide these messages from outside
+  const message = err.message || 'Server Error', // completely hide these messages from outside
     code = 500;
 
   sendDefaultResponseForCode(code, message, res);


### PR DESCRIPTION
If we're gonna go to the trouble of creating an error message, the least we could do is make sure it's returned in our response!