### PR TITLE
compose json endpoints

### DIFF
--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -154,9 +154,8 @@ route = _.bindAll({
       case 'html':
         return this.render(req, res);
       case 'json':
-        return this.getComposed(req, res);
       default:
-        return this.get(req, res);
+        return this.getComposed(req, res);
     }
   },
 
@@ -176,14 +175,13 @@ route = _.bindAll({
             });
         }, res);
       case 'json':
+      default:
         return responses.expectJSON(function () {
           return controller.put(req.uri, req.body, res.locals)
             .then(function () {
               return getComposed(req.uri, res.locals);
             });
         }, res);
-      default:
-        return this.put(req, res);
     }
   },
 

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -20,6 +20,19 @@ const _ = require('lodash'),
 let validation, route;
 
 /**
+ * get composed component data
+ * @param  {string} uri    of root component
+ * @param  {object} locals
+ * @return {Promise}        composed data of root component and children
+ */
+function getComposed(uri, locals) {
+  return controller.get(uri, locals).then(function (data) {
+    // require here because otherwise it's a circular dependency (via html-composer)
+    return require('../services/composer').resolveComponentReferences(data, locals);
+  });
+}
+
+/**
  * Validation of component routes goes here.
  *
  * They will all have the form (req, res, next).
@@ -64,6 +77,16 @@ route = _.bindAll({
   get(req, res) {
     responses.expectJSON(function () {
       return controller.get(req.uri, res.locals);
+    }, res);
+  },
+
+  /**
+   * @param {object} req
+   * @param {object} res
+   */
+  getComposed(req, res) {
+    responses.expectJSON(function () {
+      return getComposed(req.uri, res.locals);
     }, res);
   },
 
@@ -130,7 +153,8 @@ route = _.bindAll({
     switch (req.params.ext.toLowerCase()) {
       case 'html':
         return this.render(req, res);
-      case 'json': // jshint ignore:line
+      case 'json':
+        return this.getComposed(req, res);
       default:
         return this.get(req, res);
     }
@@ -151,7 +175,13 @@ route = _.bindAll({
               return htmlComposer.renderComponent(req.uri, res, _.pick(req.query, queryStringOptions));
             });
         }, res);
-      case 'json': // jshint ignore:line
+      case 'json':
+        return responses.expectJSON(function () {
+          return controller.put(req.uri, req.body, res.locals)
+            .then(function () {
+              return getComposed(req.uri, res.locals);
+            });
+        }, res);
       default:
         return this.put(req, res);
     }
@@ -176,6 +206,7 @@ route = _.bindAll({
   }
 }, [
   'get',
+  'getComposed',
   'list',
   'published',
   'put',

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -10,10 +10,33 @@ const _ = require('lodash'),
   responses = require('../responses'),
   htmlComposer = require('../html-composer'),
   controller = require('../services/pages'),
+  db = require('../services/db'),
+  components = require('../services/components'),
+  references = require('../services/references'),
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
   };
+
+/**
+ * get composed component data
+ * @param  {string} uri    of root component
+ * @param  {object} locals
+ * @return {Promise}        composed data of root component and children
+ */
+function getComposed(uri, locals) {
+  return db.get(uri).then(JSON.parse).then(function (result) {
+    const layoutReference = result.layout,
+      pageData = references.omitPageConfiguration(result);
+
+    return components.get(layoutReference)
+      .then(htmlComposer.mapLayoutToPageData.bind(this, pageData))
+      .then(function (fullData) {
+        // require here because otherwise it's a circular dependency (via html-composer)
+        return require('../services/composer').resolveComponentReferences(fullData, locals);
+      });
+  });
+}
 
 /**
  * All routes go here.
@@ -53,6 +76,7 @@ let route = _.bindAll({
    *
    * @param {object} req
    * @param {object} res
+   * @returns {Promise}
    */
   extension(req, res) {
     switch (req.params.ext.toLowerCase()) {
@@ -60,7 +84,10 @@ let route = _.bindAll({
         req.headers.accept = 'text/html';
         this.render(req, res);
         break;
-      case 'json': // jshint ignore:line
+      case 'json':
+        return responses.expectJSON(function () {
+          return getComposed(req.uri, res.locals);
+        }, res);
       default:
         req.headers.accept = 'application/json';
         responses.getRouteFromDB(req, res);

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -85,13 +85,10 @@ let route = _.bindAll({
         this.render(req, res);
         break;
       case 'json':
+      default:
         return responses.expectJSON(function () {
           return getComposed(req.uri, res.locals);
         }, res);
-      default:
-        req.headers.accept = 'application/json';
-        responses.getRouteFromDB(req, res);
-        break;
     }
   },
   /**

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -27,12 +27,16 @@ For a broader and less specific overview of routing, please see the [project's r
 /components/:name
 /components/:name@:version
 /components/:name.html
+/components/:name.json
 /components/:name@:version.html
+/components/:name@:version.json
 /components/:name/instances
 /components/:name/instances/:id
 /components/:name/intsances/:id.html
+/components/:name/intsances/:id.json
 /components/:name/instances/:id@:version
 /components/:name/instances/:id@:version.html
+/components/:name/instances/:id@:version.json
 ```
 
 ### List of components
@@ -59,6 +63,9 @@ Example: `GET /components/text/instances`
 ]
 ```
 
+### Component Data
+
+You can grab the default data for a component, data for a specific instance, or even data for a specific version (of an instance). GETs and PUTs to these endpoints behave as you would expect from a RESTful api (they return what you send them). GETs and PUTs to the `.json` and `.html` extensions also work, but they'll return the composed (i.e. a component and its children) JSON and HTML, respectively.
 
 ### Modifying components
 `GET /components/:name[/instances/:id][@:version[.:extension]]` will return a component.  The form the data is based on the extension (.html, .json, .yaml), or the Accepts header of the request.  
@@ -103,8 +110,10 @@ module.exports.del = function (ref) {
 ```
 /pages
 /pages/:name
+/pages/:name.json
 /pages/:name@:version
 /pages/:name@:version.html
+/pages/:name@:version.json
 ```
 
 Pages consist of a layout and a list of areas.  Each area defined in a page maps to a area in the layout template.  For example:
@@ -119,6 +128,10 @@ Pages consist of a layout and a list of areas.  Each area defined in a page maps
 }
 ```
 The layout component in this example has two areas: center and side.  When the page is displayed, the components listed here will be placed into the matching areas in the layout.
+
+### Page Data
+
+GETs and PUTs to pages work similarly to components. API calls without an extension will update/return data for that page, while the `.json` and `.html` extensions will return the composed (page and layout, and their child components) JSON and HTML, respectively.
 
 ### Publishing
 

--- a/lib/routes/readme.md
+++ b/lib/routes/readme.md
@@ -110,6 +110,7 @@ module.exports.del = function (ref) {
 ```
 /pages
 /pages/:name
+/pages/:name.html
 /pages/:name.json
 /pages/:name@:version
 /pages/:name@:version.html

--- a/test/api/components/get.js
+++ b/test/api/components/get.js
@@ -13,9 +13,16 @@ describe(endpointName, function () {
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
       data = { name: 'Manny', species: 'cat' },
+      deepData = { d: 'e' },
       // todo: Stop putting internal information into something we're going to open-source
       componentList = ['clay-c5', 'clay-c3', 'clay-c4'],
-      message406 = '406 text/html not acceptable';
+      message406 = '406 text/html not acceptable',
+      cascadingData = function (ref) {
+        return {a: 'b', c: {_ref: `localhost.example.com/components/${ref}`}};
+      },
+      cascadingReturnData = function (ref) {
+        return {a: 'b', c: {_ref: `localhost.example.com/components/${ref}`, d: 'e'}};
+      };
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
@@ -62,12 +69,13 @@ describe(endpointName, function () {
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data
+          '/components/valid': cascadingData('valid-deep'),
+          '/components/valid-deep': deepData
         }});
       });
 
       acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid'}, 200, cascadingReturnData('valid-deep'));
       acceptsJson(path, {name: 'missing'}, 404);
 
       acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
@@ -203,12 +211,13 @@ describe(endpointName, function () {
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid': data
+          '/components/valid/instances/valid': cascadingData('valid-deep/instances/valid-deep'),
+          '/components/valid-deep/instances/valid-deep': deepData
         }});
       });
 
       acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, data);
+      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, cascadingReturnData('valid-deep/instances/valid-deep'));
       acceptsJson(path, {name: 'valid', id: 'missing'}, 404);
 
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -185,7 +185,7 @@ describe(endpointName, function () {
       acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
+      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingData());
 
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
       acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);

--- a/test/api/pages/get.js
+++ b/test/api/pages/get.js
@@ -21,6 +21,14 @@ describe(endpointName, function () {
         layout: layoutData,
         firstLevelComponent: deepData,
         secondLevelComponent: componentData
+      },
+      deepPageData = {
+        center: [{ _ref: 'localhost.example.com/components/valid' }],
+        deep: [{
+          _ref: 'localhost.example.com/components/validDeep',
+          name: 'Manny',
+          species: 'cat'
+        }]
       };
 
     beforeEach(function () {
@@ -67,11 +75,16 @@ describe(endpointName, function () {
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
+          '/components/layout': data.layout,
+          '/components/layoutCascading': data.firstLevelComponent,
+          '/components/valid': data.firstLevelComponent,
+          '/components/validCascading': data.firstLevelComponent,
+          '/components/validDeep': data.secondLevelComponent,
           '/pages/valid': data.page
         }});
       });
 
-      acceptsJson(path, {name: 'valid'}, 200, pageData);
+      acceptsJson(path, {name: 'valid'}, 200, deepPageData);
       acceptsJson(path, {name: 'missing'}, 404, { message: 'Not Found', code: 404 });
       acceptsHtml(path, {name: 'valid'}, 406, '406 text/html not acceptable');
       acceptsHtml(path, {name: 'missing'}, 406, '406 text/html not acceptable');

--- a/test/api/users/get.js
+++ b/test/api/users/get.js
@@ -12,9 +12,7 @@ describe(endpointName, function () {
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      data = { name: 'Manny', species: 'cat' },
-      // todo: Stop putting internal information into something we're going to open-source
-      componentList = ['clay-c5', 'clay-c3', 'clay-c4'],
+      data = { username: 'manny', provider: 'google' },
       message406 = '406 text/html not acceptable';
 
     beforeEach(function () {
@@ -25,23 +23,23 @@ describe(endpointName, function () {
       sandbox.restore();
     });
 
-    describe('/components', function () {
+    describe('/users', function () {
       const path = this.title;
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname });
       });
 
-      acceptsJson(path, {}, 200, componentList);
+      acceptsJson(path, {}, 200, []);
       acceptsHtml(path, {}, 406, message406);
     });
 
-    describe('/components/:name', function () {
+    describe('/users/:name', function () {
       const path = this.title;
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data
+          '/users/valid': data
         }});
       });
 
@@ -49,217 +47,12 @@ describe(endpointName, function () {
       acceptsJson(path, {name: 'valid'}, 200, data);
       acceptsJson(path, {name: 'missing'}, 404);
 
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
+      acceptsHtml(path, {name: 'invalid'}, 406, message406);
       acceptsHtml(path, {name: 'valid'}, 406, message406);
       acceptsHtml(path, {name: 'missing'}, 406, message406);
 
       // deny trailing slash
       acceptsJson(path + '/', {name: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name.json', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 200, data);
-      acceptsJson(path, {name: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid'}, 406, message406);
-      acceptsHtml(path, {name: 'missing'}, 406, message406);
-    });
-
-    describe('/components/:name/schema', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 200, {some:'schema', thatIs:'valid'});
-      acceptsJson(path, {name: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid'}, 406, message406);
-      acceptsHtml(path, {name: 'missing'}, 406, message406);
-    });
-
-    describe('/components/:name.html', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
-      acceptsJson(path, {name: 'missing'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
-
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid'}, 200,
-        '<valid>{' +
-        '"_components":["valid"],' +
-        '"name":"Manny",' +
-        '"species":"cat",' +
-        '"template":"valid",' +
-        '"_self":"localhost.example.com/components/valid"' +
-        '}</valid>');
-      acceptsHtml(path, {name: 'missing'}, 404, '404 Not Found');
-    });
-
-    describe('/components/:name.bad', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 404, '{"message":"Not Found","code":404}');
-      acceptsJson(path, {name: 'missing'}, 404, '{"message":"Not Found","code":404}');
-
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'missing'}, 404, '404 Not Found');
-    });
-
-    describe('/components/:name@:version', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid@valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', version: 'missing'}, 404);
-      acceptsJson(path, {name: 'valid', version: 'missing'}, 404);
-      acceptsJson(path, {name: 'valid', version: 'valid'}, 200, data);
-      acceptsJson(path, {name: 'missing', version: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid', version: 'missing'}, 404);
-      acceptsHtml(path, {name: 'valid', version: 'missing'}, 406);
-      acceptsHtml(path, {name: 'missing', version: 'missing'}, 406);
-
-      // deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', version: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name/instances', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid': data,
-          '/components/valid/instances/valid': data,
-          '/components/valid/instances/valid@valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      // no versioned or base instances in list
-      acceptsJson(path, {name: 'valid'}, 200, '["localhost.example.com/components/valid/instances/valid"]');
-      acceptsJson(path, {name: 'missing'}, 200, '[]');
-
-      acceptsHtml(path, {name: 'invalid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
-    });
-
-    describe('/components/:name/instances/:id', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, data);
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
-
-      // deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name/instances/:id.json', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, data);
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
-    });
-
-    describe('/components/:name/instances/:id.html', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 406, '{"message":"application/json not acceptable","code":406,"accept":["text/html"]}');
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 200, '<valid>{' +
-        '"_components":["valid"],' +
-        '"name":"Manny",' +
-        '"species":"cat",' +
-        '"template":"valid",' +
-        '"_self":"localhost.example.com/components/valid/instances/valid"' +
-        '}</valid>');
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 404, '404 Not Found');
-    });
-
-    describe('/components/:name/instances/:id@:version', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid@valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', version: 'missing', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', version: 'valid', id: 'valid'}, 200, data);
-      acceptsJson(path, {name: 'valid', version: 'missing', id: 'valid'}, 404);
-      acceptsJson(path, {name: 'valid', version: 'missing', id: 'missing'}, 404);
-
-      acceptsHtml(path, {name: 'invalid', version: 'missing', id: 'valid'}, 404, '404 Not Found');
-      acceptsHtml(path, {name: 'valid', version: 'missing', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', version: 'missing', id: 'missing'}, 406);
-
-      // deny trailing slash
-      acceptsJson(path + '/', {name: 'valid', version: 'valid', id: 'valid'}, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
   });
 });

--- a/test/api/users/put.js
+++ b/test/api/users/put.js
@@ -4,7 +4,6 @@ const _ = require('lodash'),
   apiAccepts = require('../../fixtures/api-accepts'),
   endpointName = _.startCase(__dirname.split('/').pop()),
   filename = _.startCase(__filename.split('/').pop().split('.').shift()),
-  replaceVersion = require('../../../lib/services/references').replaceVersion,
   sinon = require('sinon');
 
 describe(endpointName, function () {
@@ -14,18 +13,7 @@ describe(endpointName, function () {
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
       acceptsJsonBody = apiAccepts.acceptsJsonBody(_.camelCase(filename)),
       acceptsHtml = apiAccepts.acceptsHtml(_.camelCase(filename)),
-      acceptsHtmlBody = apiAccepts.acceptsHtmlBody(_.camelCase(filename)),
-      cascades = apiAccepts.cascades(_.camelCase(filename)),
-      data = { name: 'Manny', species: 'cat' },
-      cascadingTarget = 'localhost.example.com/components/validDeep',
-      addVersion = _.partial(replaceVersion, cascadingTarget),
-      cascadingData = function (version) {
-        return {a: 'b', c: {_ref: addVersion(version), d: 'e'}};
-      },
-      cascadingReturnData = function (version) {
-        return {a: 'b', c: {_ref: addVersion(version)}};
-      },
-      cascadingDeepData = {d: 'e'};
+      data = { username: 'manny', provider: 'google' };
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
@@ -35,240 +23,36 @@ describe(endpointName, function () {
       sandbox.restore();
     });
 
-    describe('/components', function () {
+    describe('/users', function () {
       const path = this.title;
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname });
       });
 
-      acceptsJson(path, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJsonBody(path, {}, {}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJson(path, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
+      acceptsJsonBody(path, {}, {}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
       acceptsHtml(path, {}, 405);
     });
 
-    describe('/components/:name', function () {
+    describe('/users/:name', function () {
       const path = this.title;
 
       beforeEach(function () {
         return apiAccepts.beforeEachTest({ sandbox, hostname });
       });
 
-      acceptsJson(path, {name: 'invalid'}, 404, { code: 404, message: 'Not Found' });
       acceptsJson(path, {name: 'valid'}, 200, {});
       acceptsJson(path, {name: 'missing'}, 200, {});
 
-      acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
       acceptsJsonBody(path, {name: 'valid'}, data, 200, data);
       acceptsJsonBody(path, {name: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
 
-      acceptsHtml(path, {name: 'invalid'}, 404);
       acceptsHtml(path, {name: 'valid'}, 406);
       acceptsHtml(path, {name: 'missing'}, 406);
-
-      cascades(path, {name: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
 
       // deny trailing slashes
       acceptsJsonBody(path + '/', {name: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name/schema', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404);
-      acceptsJson(path, {name: 'valid'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJson(path, {name: 'missing'}, 405, { allow:['get'], code: 405, message: 'Method PUT not allowed' });
-
-      acceptsHtml(path, {name: 'invalid'}, 404);
-      acceptsHtml(path, {name: 'valid'}, 405);
-      acceptsHtml(path, {name: 'missing'}, 405);
-    });
-
-    describe('/components/:name@:version', function () {
-      const path = this.title,
-        version = 'def';
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid', version}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', version}, 200, {});
-      acceptsJson(path, {name: 'missing', version}, 200, {});
-
-      acceptsJsonBody(path, {name: 'invalid', version}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', version}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', version}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version}, cascadingData(), 200, cascadingReturnData());
-
-      acceptsHtml(path, {name: 'invalid', version}, 404);
-      acceptsHtml(path, {name: 'valid', version}, 406);
-      acceptsHtml(path, {name: 'missing', version}, 406);
-
-      cascades(path, {name: 'valid', version}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid', version}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-
-      // deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', version}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name/instances', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJson(path, {name: 'missing'}, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
-
-      acceptsJsonBody(path, {name: 'invalid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
-      acceptsJsonBody(path, {name: 'missing'}, data, 405, { allow:['get', 'post'], code: 405, message: 'Method PUT not allowed' });
-
-      acceptsHtml(path, {name: 'invalid'}, 404);
-      acceptsHtml(path, {name: 'valid'}, 406);
-      acceptsHtml(path, {name: 'missing'}, 406);
-    });
-
-    describe('/components/:name/instances/:id', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, {});
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 200, {});
-
-      acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
-
-      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-
-      // deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
-    });
-
-    describe('/components/:name/instances/:id.json', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 200, {});
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 200, {});
-
-      acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingReturnData());
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsHtml(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', id: 'missing'}, 406);
-
-      cascades(path, {name: 'valid', id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-    });
-
-    describe('/components/:name/instances/:id.html', function () {
-      const path = this.title;
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname });
-      });
-
-      acceptsJson(path, {name: 'invalid', id: 'valid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', id: 'valid'}, 406);
-      acceptsJson(path, {name: 'valid', id: 'missing'}, 406);
-
-      acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);
-      acceptsHtmlBody(path, {name: 'valid', id: 'valid'}, data, 200, '<valid>{' +
-      '"_components":["valid"],' +
-      '"name":"Manny",' +
-      '"species":"cat",' +
-      '"template":"valid",' +
-      '"_self":"localhost.example.com/components/valid/instances/valid"' +
-      '}</valid>');
-      acceptsHtmlBody(path, {name: 'valid', id: 'missing'}, data, 200, '<valid>{' +
-      '"_components":["valid"],' +
-      '"name":"Manny",' +
-      '"species":"cat",' +
-      '"template":"valid",' +
-      '"_self":"localhost.example.com/components/valid/instances/missing"' +
-      '}</valid>');
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid', id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-    });
-
-    describe('/components/:name/instances/:id@:version', function () {
-      let path = this.title,
-        version = 'def';
-
-      beforeEach(function () {
-        return apiAccepts.beforeEachTest({ sandbox, hostname, pathsAndData: {
-          '/components/valid/instances/valid': data
-        }});
-      });
-
-      acceptsJson(path, {name: 'invalid', version, id: 'valid'}, 404, { code: 404, message: 'Not Found' });
-      acceptsJson(path, {name: 'valid', version, id: 'valid'}, 200, {});
-      acceptsJson(path, {name: 'valid', version, id: 'missing'}, 200, {});
-
-      acceptsJsonBody(path, {name: 'invalid', version, id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', version, id: 'missing'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, cascadingData(), 200, cascadingReturnData());
-
-      acceptsHtml(path, {name: 'invalid', version, id: 'valid'}, 404);
-      acceptsHtml(path, {name: 'valid', version, id: 'valid'}, 406);
-      acceptsHtml(path, {name: 'valid', version, id: 'missing'}, 406);
-
-      cascades(path, {name: 'valid', version, id: 'valid'}, cascadingData(), cascadingTarget, cascadingDeepData);
-
-      // published version
-      version = 'published';
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, cascadingData(version), 200, cascadingReturnData(version));
-      cascades(path, {name: 'valid', version, id: 'valid'}, cascadingData(version), addVersion(version), cascadingDeepData);
-
-      // published blank data will publish @latest
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, {}, 200, data);
-      // publishing blank data without a @latest will 404 because missing resource
-      acceptsJsonBody(path, {name: 'valid', version, id: 'missing'}, {}, 404, { code: 404, message: 'Not Found' });
-
-      // block with _ref at root of object
-      acceptsJsonBody(path, {name: 'valid', version, id: 'valid'}, _.assign({_ref: 'whatever'}, data), 400, {message: 'Reference (_ref) at root of object is not acceptable', code: 400});
-
-      // deny trailing slashes
-      acceptsJsonBody(path + '/', {name: 'valid', version, id: 'valid'}, data, 400, { message: 'Trailing slash on RESTful id in URL is not acceptable', code: 400 });
     });
   });
 });


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/z2PMqiq6/73-amphora-should-have-a-composed-json-endpoint)
* `.json` extension endpoints now compose page and component data
* this matches how `.html` endpoints return data
* this works for both GETs and PUTs to the relevant endpoints
* I also cleaned up the `/users` api tests