### PR TITLE
Search Config

### DIFF
--- a/lib/services/search.js
+++ b/lib/services/search.js
@@ -20,7 +20,8 @@ const elastic = require('elasticsearch'),
   searchDir = '/search';
 
 // Reference to the ES client
-var client;
+var client,
+  indexPrefix;
 
 
 /**
@@ -341,15 +342,19 @@ function createClient(overrideClient) {
  * @param {Object} [overrideClient]
  * @return {Promise}
  */
-function setup(overrideClient) {
-  // Create client + check the connection
-  return createClient(overrideClient)
-    .then(healthCheck)
-    // .then(createInternalIndices)
-    .then(setupMappings)
-    .catch(function (err) {
-      return bluebird.reject(err);
-    });
+function setup(searchConfig) {
+  indexPrefix = module.exports.indexPrefix = searchConfig.indexPrefix || '';
+
+  return function(overrideClient) {
+    // Create client + check the connection
+    return createClient(overrideClient)
+      .then(healthCheck)
+      // .then(createInternalIndices)
+      .then(setupMappings)
+      .catch(function (err) {
+        return bluebird.reject(err);
+      });
+  }
 }
 
 /**
@@ -379,7 +384,7 @@ function validateIndices(mappings) {
  * The name of the file becomes the name of the index (convention over configuration).
  *
  * @param {string} dirPath
-* @param {string} prefix
+ * @param {string} prefix
  * @returns {object}
  */
 function retrieveMappingData(dirPath, prefix) {
@@ -426,7 +431,7 @@ function setupMappings(overrideDir) {
   var externalSearch = moduleExists(process.cwd() + (overrideDir || searchDir));
 
   if (externalSearch) {
-    return externalSearch();
+    return externalSearch(indexPrefix);
   }
 
   return bluebird.resolve();

--- a/lib/services/search.js
+++ b/lib/services/search.js
@@ -339,13 +339,13 @@ function createClient(overrideClient) {
  * ES client. This is used for testing, but in production
  * `overrideClient` will be undefined.
  *
- * @param {Object} [overrideClient]
+ * @param {Object} searchConfig
  * @return {Promise}
  */
 function setup(searchConfig) {
   indexPrefix = module.exports.indexPrefix = searchConfig.indexPrefix || '';
 
-  return function(overrideClient) {
+  return function (overrideClient) {
     // Create client + check the connection
     return createClient(overrideClient)
       .then(healthCheck)
@@ -354,7 +354,7 @@ function setup(searchConfig) {
       .catch(function (err) {
         return bluebird.reject(err);
       });
-  }
+  };
 }
 
 /**

--- a/lib/services/search.test.js
+++ b/lib/services/search.test.js
@@ -41,7 +41,7 @@ describe(_.startCase(filename), function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(client);
     sandbox.stub(client.indices);
-    lib.setup(client);
+    lib.setup({})(client);
   });
 
   afterEach(function () {
@@ -58,13 +58,18 @@ describe(_.startCase(filename), function () {
     });
 
     it('returns an instance with fake client if one is passed in', function () {
-      lib.setup(client);
+      lib.setup({})(client);
       expect(lib.client).to.deep.equal(client);
+    });
+
+    it('sets the prefix for the indices', function () {
+      lib.setup({indexPrefix: 'somePrefix'})(client);
+      expect(lib.indexPrefix).to.deep.equal('somePrefix');
     });
 
     it('creates an Elastic client if an endpoint is defined and no override is passed in', function () {
       lib.endpoint = 'whatever';
-      lib.setup();
+      lib.setup({})();
       expect(lib.client).to.not.deep.equal({});
     });
   });

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -23,13 +23,14 @@ bluebird.config({
  * @returns {Promise}
  */
 module.exports = function (options) {
-  let app, engines, providers, router, sessionStore;
+  let app, engines, providers, router, sessionStore, searchConfig;
 
   options = options || {};
   app = options.app || express(); // use new express app if not passed in
   engines = options.engines; // will be undefined if not passed in
   providers = options.providers || [];
   sessionStore = options.sessionStore;
+  searchConfig = options.search || {}; // Config object to pass to the search setup
 
   // init the router
   router = routes(app, providers, sessionStore);
@@ -40,7 +41,7 @@ module.exports = function (options) {
   }
 
   return bootstrap() // look for bootstraps in components
-    .then(search.setup) // setup search
+    .then(search.setup(searchConfig)) // setup search
     .then(searchRoute(router))  // search route needs to be set up at base url
     .return(router);
 };


### PR DESCRIPTION
Creates a config object that allows us to pass data to the search service from a Clay implementation. 