### PR TITLE
update unpub notify to send url

### DIFF
--- a/lib/services/uris.js
+++ b/lib/services/uris.js
@@ -6,6 +6,16 @@ const _ = require('lodash'),
   notifications = require('./notifications'),
   siteService = require('./sites');
 
+
+/**
+ * decode string from base64
+ * @param {string} string
+ * @returns {string} decoded stirng
+ */
+function decode(string) {
+  return new Buffer(string, 'base64').toString('utf8');
+}
+
 /**
  * @param {string} uri
  * @returns {Promise}
@@ -51,7 +61,7 @@ function del(uri, locals) {
       const prefix = references.getUriPrefix(uri),
         site = siteService.getSiteFromPrefix(prefix);
 
-      notifications.notify(site, 'unpublished', oldData);
+      notifications.notify(site, 'unpublished', { url: decode(uri.split('/').pop())});
     }).return(oldData);
   });
 }

--- a/lib/services/uris.test.js
+++ b/lib/services/uris.test.js
@@ -28,9 +28,9 @@ describe(_.startCase(filename), function () {
     const fn = lib[this.title];
 
     it('notifies', function () {
-      const uri = 'something/uris/some-uri',
+      const uri = 'something/uris/bmljZXVybA==',
         site = {a: 'b'},
-        oldData = {c: 'd'};
+        oldData = {url: 'niceurl'};
 
       db.del.returns(bluebird.resolve());
       db.get.returns(bluebird.resolve(oldData));


### PR DESCRIPTION
The unpublish notifier was sending the url of the internal clay page, which is of no use to external systems trying to handle unpublish of a public url.  This update sends the public url of the unpublished page (in json package). 