### PR TITLE
new models

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -246,9 +246,7 @@ function setRequire(value) {
 }
 
 /**
- * Load a component as a node module.
- *
- * Should only occur once per name!
+ * Load a component model
  *
  * NOTE: This includes local components as well as npm components.
  *
@@ -258,7 +256,11 @@ function setRequire(value) {
 function getComponentModule(name) {
   let componentPath = exports.getComponentPath(name);
 
-  return componentPath && tryRequireEach([componentPath, componentPath + '/server']);
+  // tries to grab:
+  // componentPath/model.js
+  // componentPath/index.js (deprecated)
+  // componentPath/server.js (deprecated)
+  return componentPath && tryRequireEach([componentPath + '/model', componentPath, componentPath + '/server']);
 }
 
 /**

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -278,6 +278,17 @@ describe(_.startCase(filename), function () {
       expect(fn(name)).to.equal(undefined);
     });
 
+    it('handles model.js path', function () {
+      const name = 'some name',
+        path = 'some path',
+        result = 'some result';
+
+      lib.getComponentPath.returns(path);
+      req.withArgs(path + '/model').returns(result);
+
+      expect(fn(name)).to.equal(result);
+    });
+
     it('handles index.js path', function () {
       const name = 'some name',
         path = 'some path',

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -72,10 +72,14 @@ function get(uri, locals) {
 
     promise = bluebird.try(function () {
       if (_.isFunction(componentModule.render)) {
-        // model.js syntax
-        return bluebird.resolve(componentModule.render(uri, locals));
+        // model.js syntax gets the data from the db passed into it
+        return db.get(uri)
+          .then(JSON.parse)
+          .then(function (data) {
+            return componentModule.render(uri, data, locals);
+          });
       } else {
-        // deprecated server.js syntax
+        // deprecated server.js syntax only gets uri and locals
         return componentModule(uri, locals);
       }
     }).tap(function (result) {

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -62,13 +62,23 @@ function getName(uri) {
 function get(uri, locals) {
   let promise,
     name = getName(uri),
-    componentModule = name && files.getComponentModule(name);
+    componentModule = name && files.getComponentModule(name),
+    callComponentHooks = _.get(locals, 'componenthooks') !== 'false';
 
-  if (_.isFunction(componentModule)) {
+  // check for model.render() (plus no componenthooks flag), or the deprecated server() syntax
+  if (componentModule && _.isFunction(componentModule.render) && callComponentHooks || _.isFunction(componentModule)) {
     const startTime = process.hrtime(),
       timeoutLimit = timeoutConstant * timeoutGetCoefficient;
 
-    promise = bluebird.try(function () { return componentModule(uri, locals); }).tap(function (result) {
+    promise = bluebird.try(function () {
+      if (_.isFunction(componentModule.render)) {
+        // model.js syntax
+        return bluebird.resolve(componentModule.render(uri, locals));
+      } else {
+        // deprecated server.js syntax
+        return componentModule(uri, locals);
+      }
+    }).tap(function (result) {
       const ms = timer.getMillisecondsSince(startTime);
 
       if (!_.isObject(result)) {
@@ -173,14 +183,34 @@ function putDefaultBehavior(uri, data) {
  */
 function put(uri, data, locals) {
   let result,
-    componentModule = files.getComponentModule(getName(uri));
+    componentModule = files.getComponentModule(getName(uri)),
+    callComponentHooks = _.get(locals, 'componenthooks') !== 'false';
 
-  if (componentModule && _.isFunction(componentModule.put)) {
+  // check for model.save() (plus no componenthooks flag), or the deprecated server.put() syntax
+  if (componentModule && (_.isFunction(componentModule.save) && callComponentHooks || _.isFunction(componentModule.put))) {
     const startTime = process.hrtime(),
       timeoutLimit = timeoutConstant * timeoutPutCoefficient;
 
     result = bluebird.try(function () {
-      return componentModule.put(uri, data, locals);
+      if (_.isFunction(componentModule.save)) {
+        // model.js syntax, model.save should return an object (Promisified or regular)
+        // THEN we create operations for the database batch
+        return bluebird.resolve(componentModule.save(uri, data, locals)).then(function (resolvedData) {
+          if (!_.isObject(resolvedData)) {
+            throw new Error(`Unable to save ${uri}: Data from model.save must be an object!`);
+          }
+
+          return {
+            key: uri,
+            type: 'put',
+            value: JSON.stringify(resolvedData)
+          };
+        });
+      } else {
+        // deprecated server.js syntax
+        // server.put should return an operation or array of operations
+        return componentModule.put(uri, data, locals);
+      }
     }).tap(function () {
       const ms = timer.getMillisecondsSince(startTime);
 

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -509,7 +509,8 @@ describe(_.startCase(filename), function () {
       const ref = 'domain.com/path/components/whatever',
         renderSpy = sinon.stub();
 
-      renderSpy.returns({ _ref: ref, a: 'b' });
+      db.get.returns(Promise.resolve(JSON.stringify({a: 'b'})));
+      renderSpy.returns({ a: 'b' });
       files.getComponentModule.returns({render: renderSpy});
       return fn(ref).then(function () {
         sinon.assert.called(files.getComponentModule);
@@ -521,6 +522,7 @@ describe(_.startCase(filename), function () {
       const ref = 'domain.com/path/components/whatever',
         renderSpy = sinon.stub();
 
+      db.get.returns(Promise.resolve(JSON.stringify({})));
       renderSpy.returns('abc');
       files.getComponentModule.returns({render: renderSpy});
       fn(ref).then(done).catch(function (error) {
@@ -578,13 +580,15 @@ describe(_.startCase(filename), function () {
     it('gets using component model with locals', function () {
       const ref = 'domain.com/path/components/whatever',
         locals = {},
-        renderSpy = sinon.stub();
+        renderSpy = sinon.stub(),
+        data = {a: 'b'};
 
+      db.get.returns(Promise.resolve(JSON.stringify(data)));
       renderSpy.returns({ _ref: ref, a: 'b' });
       files.getComponentModule.returns({render: renderSpy});
       return fn(ref, locals).then(function () {
         sinon.assert.called(files.getComponentModule);
-        sinon.assert.calledWith(renderSpy, ref, locals);
+        sinon.assert.calledWith(renderSpy, ref, data, locals);
       });
     });
 

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -244,7 +244,7 @@ describe(_.startCase(filename), function () {
   describe('put', function () {
     const fn = lib[this.title];
 
-    it('throw exception if module does not return any ops', function (done) {
+    it('throw exception if legacy module does not return any ops', function (done) {
       const ref = 'a',
         data = {},
         putSpy = sinon.stub();
@@ -255,6 +255,21 @@ describe(_.startCase(filename), function () {
 
       fn(ref, data).then(done).catch(function (error) {
         expect(error.message).to.equal('Component module PUT failed to create batch operations: a');
+        done();
+      });
+    });
+
+    it('throw exception if model does not return object', function (done) {
+      const ref = 'a',
+        data = {},
+        putSpy = sinon.stub();
+
+      putSpy.returns('abc');
+      files.getComponentModule.returns({save: putSpy});
+      db.batch.returns(bluebird.resolve());
+
+      fn(ref, data).then(done).catch(function (error) {
+        expect(error.message).to.equal('Unable to save a: Data from model.save must be an object!');
         done();
       });
     });
@@ -314,7 +329,25 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('cascades with component modules', function () {
+    it('cascades with component models gives locals', function () {
+      const ref = 'a',
+        locals = {},
+        data = {a: 'b', c: {_ref:'d', e: 'f'}},
+        putSpy = sinon.stub();
+
+      files.getComponentModule.returns({save: putSpy});
+      db.batch.returns(bluebird.resolve());
+      putSpy.withArgs('a', sinon.match.object).returns({h: 'i'});
+      putSpy.withArgs('d', sinon.match.object).returns({k: 'l'});
+
+      return fn(ref, data, locals).then(function () {
+        sinon.assert.called(files.getComponentModule);
+        sinon.assert.calledWith(putSpy.firstCall, 'd', { e: 'f' }, locals);
+        sinon.assert.calledWith(putSpy.secondCall, 'a', { a: 'b', c: { _ref: 'd' } }, locals);
+      });
+    });
+
+    it('cascades with legacy component modules', function () {
       const ref = 'a',
         data = {a: 'b', c: {_ref:'d', e: 'f'}},
         rootModuleData = {type: 'put', key: 'g', value: JSON.stringify({h: 'i'})},
@@ -332,7 +365,7 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('cascades with component modules gives locals', function () {
+    it('cascades with legacy component modules gives locals', function () {
       const ref = 'a',
         locals = {},
         data = {a: 'b', c: {_ref:'d', e: 'f'}},
@@ -380,6 +413,18 @@ describe(_.startCase(filename), function () {
 
       return fn(ref, data).then(function (result) {
         expect(result).to.deep.equal({ a: 'b', c: { _ref: 'd' } });
+      });
+    });
+
+    it('puts with default behavior if componenthooks is explicitly false', function () {
+      const ref = 'a',
+        data = {},
+        putSpy = sinon.stub();
+
+      db.batch.returns(bluebird.resolve());
+      files.getComponentModule.returns({save: putSpy});
+      return fn(ref, data, { componenthooks: 'false' }).then(function () {
+        expect(db.batch.getCall(0).args[0]).to.deep.contain.members([{ key: 'a', type: 'put', value: '{}' }]);
       });
     });
   });
@@ -460,7 +505,43 @@ describe(_.startCase(filename), function () {
       return fn('bad name');
     });
 
-    it('gets using component module', function () {
+    it('gets using component model', function () {
+      const ref = 'domain.com/path/components/whatever',
+        renderSpy = sinon.stub();
+
+      renderSpy.returns({ _ref: ref, a: 'b' });
+      files.getComponentModule.returns({render: renderSpy});
+      return fn(ref).then(function () {
+        sinon.assert.called(files.getComponentModule);
+        sinon.assert.calledWith(renderSpy, ref);
+      });
+    });
+
+    it('blocks component model returning non-object', function (done) {
+      const ref = 'domain.com/path/components/whatever',
+        renderSpy = sinon.stub();
+
+      renderSpy.returns('abc');
+      files.getComponentModule.returns({render: renderSpy});
+      fn(ref).then(done).catch(function (error) {
+        expect(error.message).to.equal('Component module must return object, not string: domain.com/path/components/whatever');
+        done();
+      });
+    });
+
+    it('gets directly from db if componenthooks is explicitly false', function () {
+      const ref = 'domain.com/path/components/whatever',
+        renderSpy = sinon.stub();
+
+      db.get.returns(bluebird.resolve('{}'));
+      files.getComponentModule.returns({render: renderSpy});
+      return fn(ref, { componenthooks: 'false' }).then(function () {
+        sinon.assert.called(files.getComponentModule);
+        sinon.assert.calledWith(db.get, ref);
+      });
+    });
+
+    it('gets using legacy component module', function () {
       const ref = 'domain.com/path/components/whatever',
         someModule = sinon.spy(_.constant(bluebird.resolve({})));
 
@@ -471,7 +552,7 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('blocks component module returning non-object', function (done) {
+    it('blocks legacy component module returning non-object', function (done) {
       const ref = 'domain.com/path/components/whatever',
         someModule = sinon.spy(_.constant(bluebird.resolve('{}')));
 
@@ -494,7 +575,20 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('gets using component module with locals', function () {
+    it('gets using component model with locals', function () {
+      const ref = 'domain.com/path/components/whatever',
+        locals = {},
+        renderSpy = sinon.stub();
+
+      renderSpy.returns({ _ref: ref, a: 'b' });
+      files.getComponentModule.returns({render: renderSpy});
+      return fn(ref, locals).then(function () {
+        sinon.assert.called(files.getComponentModule);
+        sinon.assert.calledWith(renderSpy, ref, locals);
+      });
+    });
+
+    it('gets using legacy component module with locals', function () {
       const ref = 'domain.com/path/components/whatever',
         locals = {},
         someModule = sinon.spy(_.constant(bluebird.resolve({})));


### PR DESCRIPTION
* new component models! they're called `model.js`
* the default exported function (`GET`) is now `model.render` (it's a pre-render hook)
* `server.put` is now `model.save` (it runs on ALL saves, not just `PUT` calls)
* you can tell the server to disregard the model entirely (and get/put directly to the database) by passing the `componenthooks=false` query param (this is what kiln will do, to prevent double-logic)
* `model.render` now gets passed `uri, data, locals` rather than `uri, locals`, as the common cases for doing logic pre-render actually require the data from the db (e.g. searching). This also helps npm components which cannot access amphora directly.
* updated docs to reflect this