### PR TITLE
upped leak threshold to 32KB

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let memoryLeakThreshold = 1000;
+let memoryLeakThreshold = 32768;
 const _ = require('lodash'),
   log = require('./services/log').withStandardPrefix(__filename),
   minute = 60000;


### PR DESCRIPTION
Was set to 1000 bytes, which fills the prod logs with useless messages.  

https://trello.com/b/wRlX5ZBs/clay-platform