### PR TITLE
Rewrites files.tryRequire to fail on failed requires (inside required module)

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -175,7 +175,6 @@ function tryRequire(filePath) {
   try {
     resolvedPath = req.resolve(filePath);
   } catch (ex) {
-    console.log('undefined: ', filePath);
     return undefined;
   }
   return req(resolvedPath);

--- a/lib/files.js
+++ b/lib/files.js
@@ -170,18 +170,15 @@ function getComponentPath(name) {
  * @throw if fails for reason other than missing module
  */
 function tryRequire(filePath) {
-  let result;
+  let resolvedPath;
 
   try {
-    result = req(filePath);
+    resolvedPath = req.resolve(filePath);
   } catch (ex) {
-    if (ex.message && !ex.message.match(/Cannot find module/i)) {
-      log('error', `Failed to load ${filePath}: ${ex.message}`);
-      throw ex;
-    }
+    console.log('undefined: ', filePath);
+    return undefined;
   }
-
-  return result;
+  return req(resolvedPath);
 }
 
 /**

--- a/lib/files.js
+++ b/lib/files.js
@@ -15,7 +15,6 @@ let _ = require('lodash'),
   yaml = require('js-yaml'),
   pkg = require(path.resolve('package.json')),
   temp2env = require('template2env'),
-  log = require('./services/log').withStandardPrefix(__filename),
   req = require,
   allowedEnvFiles = ['local', 'config'];
 

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -259,7 +259,7 @@ describe(_.startCase(filename), function () {
       expect(fn(name)).to.equal(null);
     });
 
-    it('throw normal errors from require', function () {
+    it('throws an error if the module exists but cannot be required successfully', function () {
       const name = 'some name',
         path = 'some path';
 
@@ -270,7 +270,7 @@ describe(_.startCase(filename), function () {
       expect(function () { fn(name); }).to.throw();
     });
 
-    it('eats "Cannot find module" errors', function () {
+    it('returns undefined if the module does not exist', function () {
       const name = 'some name',
         path = 'some path';
 

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -51,6 +51,7 @@ describe(_.startCase(filename), function () {
 
     // require shouldn't be called dynamically, but here we go
     req = sandbox.stub();
+    req.resolve = sandbox.stub();
     lib.setRequire(req);
   });
 
@@ -262,6 +263,7 @@ describe(_.startCase(filename), function () {
       const name = 'some name',
         path = 'some path';
 
+      req.resolve.returns('/some-path');
       req.throws(new Error('some error'));
       lib.getComponentPath.returns(path);
 
@@ -272,7 +274,7 @@ describe(_.startCase(filename), function () {
       const name = 'some name',
         path = 'some path';
 
-      req.throws(new Error('Cannot find module'));
+      req.resolve.throws(new Error('Cannot find module'));
       lib.getComponentPath.returns(path);
 
       expect(fn(name)).to.equal(undefined);
@@ -284,6 +286,7 @@ describe(_.startCase(filename), function () {
         result = 'some result';
 
       lib.getComponentPath.returns(path);
+      req.resolve.withArgs(path + '/model').returns(path + '/model');
       req.withArgs(path + '/model').returns(result);
 
       expect(fn(name)).to.equal(result);
@@ -295,6 +298,7 @@ describe(_.startCase(filename), function () {
         result = 'some result';
 
       lib.getComponentPath.returns(path);
+      req.resolve.withArgs(path).returns(path);
       req.withArgs(path).returns(result);
 
       expect(fn(name)).to.equal(result);
@@ -306,6 +310,7 @@ describe(_.startCase(filename), function () {
         result = 'some result';
 
       lib.getComponentPath.returns(path);
+      req.resolve.withArgs(path + '/server').returns(path + '/server');
       req.withArgs(path + '/server').returns(result);
 
       expect(fn(name)).to.equal(result);
@@ -343,6 +348,7 @@ describe(_.startCase(filename), function () {
         result = [];
 
       lib.getComponentPath.returns(path);
+      req.resolve.withArgs(path + '/package.json').returns(path + '/package.json');
       req.withArgs(path + '/package.json').returns(result);
 
       expect(fn(name)).to.equal(result);


### PR DESCRIPTION
We use `files.tryRequire` so we don't have to worry about whether JS files exists or not — for example, a component lacking a `server.js` will not throw an error.

But because of the way it is currently written, `files.tryRequire` will return successfully if the required module or any descendant module includes an invalid `require` call. This is bad for development because a `server.js` or a site `index.js` that has a bad `require` path will fail silently. No errors from real JS files should be swallowed.

This change rewrites the function to return successfully only when one of two conditions are met:

* The required module does not exist (returns `undefined`).
* The required module exists and can be `require`'ed successfully (returns the module).

In other words, the function will throw an error in all cases in which the module required via `files.tryRequire` _does_ exist but cannot be imported successfully.