### PR TITLE
Moves page composer function to composer service

### DIFF
--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -11,8 +11,6 @@ const _ = require('lodash'),
   htmlComposer = require('../html-composer'),
   controller = require('../services/pages'),
   db = require('../services/db'),
-  components = require('../services/components'),
-  references = require('../services/references'),
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
@@ -25,17 +23,10 @@ const _ = require('lodash'),
  * @return {Promise}        composed data of root component and children
  */
 function getComposed(uri, locals) {
-  return db.get(uri).then(JSON.parse).then(function (result) {
-    const layoutReference = result.layout,
-      pageData = references.omitPageConfiguration(result);
-
-    return components.get(layoutReference)
-      .then(htmlComposer.mapLayoutToPageData.bind(this, pageData))
-      .then(function (fullData) {
-        // require here because otherwise it's a circular dependency (via html-composer)
-        return require('../services/composer').resolveComponentReferences(fullData, locals);
-      });
-  });
+  return db.get(uri)
+    .then(JSON.parse)
+    // require here because otherwise it's a circular dependency (via html-composer)
+    .then(pageData => require('../services/composer').composePage(pageData, locals));
 }
 
 /**

--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -6,13 +6,14 @@ const _ = require('lodash'),
   references = require('./references'),
   referenceProperty = '_ref';
 
+
 /**
- * Find all _ref, and recursively expand them.
- *
+ * Compose a component, recursively filling in all component references with
+ * instance data.
  * @param {object} data
  * @param {object} locals  Extra data that some GETs use
  * @param {function|string} [filter='_ref']
- * @returns {Promise}
+ * @returns {Promise} - Resolves with composed component data
  */
 function resolveComponentReferences(data, locals, filter) {
   const referenceObjects = references.listDeepObjects(data, filter || referenceProperty);
@@ -33,4 +34,24 @@ function resolveComponentReferences(data, locals, filter) {
       });
   }).return(data);
 }
+
+/**
+ * Compose a page, recursively filling in all component references with
+ * instance data.
+ * @param  {object} pageData
+ * @param  {object} locals
+ * @return {Promise} - Resolves with composed page data
+ */
+function composePage(pageData, locals) {
+  const layoutReference = pageData.layout,
+    pageDataNoConf = references.omitPageConfiguration(pageData);
+
+  return components.get(layoutReference)
+    // require here because otherwise it's a circular dependency (via html-composer)
+    .then(layoutData => require('../html-composer').mapLayoutToPageData(pageDataNoConf, layoutData))
+    .then(fullData => resolveComponentReferences(fullData, locals));
+}
+
+
 module.exports.resolveComponentReferences = resolveComponentReferences;
+module.exports.composePage = composePage;

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -143,7 +143,7 @@ describe(_.startCase(filename), function () {
         layout: '/some/layout'
       };
 
-      fn(pageData, {})
+      fn(pageData)
         .then((result) => {
           expect(result).to.deep.equal({
             head: [{

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -111,4 +111,58 @@ describe(_.startCase(filename), function () {
       });
     });
   });
+
+  describe('composePage', function () {
+    const fn = lib[this.title];
+
+    beforeEach(function () {
+      components.get.withArgs('/some/layout').returns(bluebird.resolve({
+        head: 'head',
+        top: [{
+          _ref: '/e/f'
+        }]
+      }));
+
+      components.get.withArgs('/a/b').returns(bluebird.resolve({
+        _ref: '/a/b',
+        c: 'd'
+      }));
+
+      components.get.withArgs('/e/f').returns(bluebird.resolve({
+        _ref: '/e/f',
+        g: 'h'
+      }));
+
+    });
+
+    it('composes pages', function (done) {
+      const pageData = {
+        head: [
+          '/a/b'
+        ],
+        layout: '/some/layout'
+      };
+
+      fn(pageData, {})
+        .then((result) => {
+          expect(result).to.deep.equal({
+            head: [{
+              _ref: '/a/b',
+              c: 'd'
+            }],
+            top: [{
+              _ref: '/e/f',
+              g: 'h'
+            }]
+          });
+        })
+        .then(done)
+        .catch(done);
+    });
+
+    it('throws errors if page data is not defined', function () {
+      expect(()=>fnc()).to.throw(Error);
+    });
+  });
+
 });


### PR DESCRIPTION
We're moving sitemap generation logic out of Amphora ([Trello](https://trello.com/c/deJDnM1D/25-thecut-com-articles-xml-sitemap)). Part of the logic involves composing page objects. This PR move the function that composes pages into the `composer` service, thereby exposing it to modules outside of Amphora.

This change also aligns `routes/pages.js` more closely with `routes/components.js`; both now are responsible only for `get`-ing the proper object; the `composer` owns composing.
