### PR TITLE
GetSiteFromPrefix Update

### DIFF
--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -71,6 +71,7 @@ function getSites() {
       throw new Error('Missing host in site config');
     }
 
+    console.log('\n\n\n\n', siteConfig);
     // add site config to the sites map
     fullConfig[siteConfig.slug] = siteConfig;
   });
@@ -92,14 +93,29 @@ function getSite(host, path) {
 }
 
 /**
- * Get site from prefix
+ * Get the site a URI belongs to
+ *
  * @param {string} prefix
  * @returns {object}
  */
 function getSiteFromPrefix(prefix) {
-  const split = prefix.split('/');
+  var split = prefix.split('/'), // Split the url/uri by `/`
+    host = split.shift(),        // The first value should be the host ('http://' is not included)
+    path = `/${split.shift()}`,  // The next value is the first part of the site's path OR the whole part
+    length = split.length + 1,   // We always need at least one pass through the for loop
+    site;                        // Initialize the return value to `undefined`
 
-  return getSite(split[0], '/' + split[1]);
+  for (let i = 0; i < length; i++) {
+    site = getSite(host, path); // Try to get the site based on the host and path
+
+    if (site) { // If a site was found, break out of the loop
+      break;
+    } else {
+      path += `/${split.shift()}`; // Grab the next value and append it to the `path` value
+    }
+  }
+
+  return site; // Return the site
 }
 
 module.exports.sites = control.memoize(getSites);

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -71,7 +71,6 @@ function getSites() {
       throw new Error('Missing host in site config');
     }
 
-    console.log('\n\n\n\n', siteConfig);
     // add site config to the sites map
     fullConfig[siteConfig.slug] = siteConfig;
   });

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -28,6 +28,15 @@ describe(_.startCase(filename), function () {
         prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/e'
+      },
+      c: {
+        dir: 'z/c',
+        slug: 'c',
+        host: 'h',
+        path: '/i/j',
+        prefix: 'h/i/j',
+        assetDir: 'public',
+        assetPath: '/i/j'
       }
     },
     mockSitesWithoutPaths = {
@@ -92,11 +101,18 @@ describe(_.startCase(filename), function () {
     const fn = lib[this.title];
 
     it('gets', function () {
-      files.getFolders.returns(['a', 'b']);
+      files.getFolders.returns(['a', 'b', 'c']);
       path.resolve.returns('z');
       files.getYaml.onFirstCall().returns(getMockSite());
       files.getYaml.onSecondCall().returns(getMockSite());
       files.getYaml.onThirdCall().returns(getMockSite());
+      files.getYaml.onCall(4).returns({
+        assetPath: '/i/j',
+        host: 'h',
+        path: '/i/j',
+        prefix: 'h/i/j'
+      });
+
 
       expect(fn()).to.deep.equal(mockSites);
     });
@@ -150,6 +166,16 @@ describe(_.startCase(filename), function () {
       sandbox.stub(lib, 'sites').returns(mockSites);
 
       expect(fn('d/e')).to.eql(mockSites.a);
+    });
+
+    it('gets from prefix for sites with multiple slashes in the path', function () {
+      sandbox.stub(lib, 'sites').returns(mockSites);
+      expect(fn('h/i/j')).to.eql(mockSites.c);
+    });
+
+    it('returns undefined if the site cannot be found', function () {
+      sandbox.stub(lib, 'sites').returns(mockSites);
+      expect(fn('h/i')).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
The current `getSiteFromPrefix` function only accommodates for sites with one subdirectory in the `path` of a site. This updates makes it so that the function will iterate through a uri until it finds a match or return undefined.