### PR TITLE
Component Data Versioning

### DIFF
--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -21,6 +21,7 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   path = require('path'),
   glob = require('glob'),
+  upgrade = require('./upgrade'),
   referenceProperty = '_ref',
   mediaDir = path.join(process.cwd(), 'public'),
   timeoutGetCoefficient = 2,
@@ -65,6 +66,7 @@ function get(uri, locals) {
     componentModule = name && files.getComponentModule(name),
     callComponentHooks = _.get(locals, 'componenthooks') !== 'false';
 
+
   // check for model.render() (plus no componenthooks flag), or the deprecated server() syntax
   if (componentModule && _.isFunction(componentModule.render) && callComponentHooks || _.isFunction(componentModule)) {
     const startTime = process.hrtime(),
@@ -75,11 +77,14 @@ function get(uri, locals) {
         // model.js syntax gets the data from the db passed into it
         return db.get(uri)
           .then(JSON.parse)
+          .then(upgrade(uri, locals)) // Run an upgrade!
           .then(function (data) {
             return componentModule.render(uri, data, locals);
           });
       } else {
-        // deprecated server.js syntax only gets uri and locals
+        // Deprecated server.js syntax only gets uri and locals.
+        // Upgrades not supported because db request is being
+        // handled in the module.
         return componentModule(uri, locals);
       }
     }).tap(function (result) {
@@ -94,7 +99,7 @@ function get(uri, locals) {
       }
     }).timeout(timeoutLimit, 'Component module GET exceeded ' + timeoutLimit + 'ms:' + uri);
   } else {
-    promise = db.get(uri).then(JSON.parse);
+    promise = db.get(uri).then(JSON.parse).then(upgrade(uri, locals)); // Run an upgrade!
   }
 
   return promise.then(function (data) {

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -66,7 +66,6 @@ function get(uri, locals) {
     componentModule = name && files.getComponentModule(name),
     callComponentHooks = _.get(locals, 'componenthooks') !== 'false';
 
-
   // check for model.render() (plus no componenthooks flag), or the deprecated server() syntax
   if (componentModule && _.isFunction(componentModule.render) && callComponentHooks || _.isFunction(componentModule)) {
     const startTime = process.hrtime(),
@@ -77,7 +76,7 @@ function get(uri, locals) {
         // model.js syntax gets the data from the db passed into it
         return db.get(uri)
           .then(JSON.parse)
-          .then(upgrade(uri, locals)) // Run an upgrade!
+          .then(upgrade.init(uri, locals)) // Run an upgrade!
           .then(function (data) {
             return componentModule.render(uri, data, locals);
           });
@@ -99,7 +98,7 @@ function get(uri, locals) {
       }
     }).timeout(timeoutLimit, 'Component module GET exceeded ' + timeoutLimit + 'ms:' + uri);
   } else {
-    promise = db.get(uri).then(JSON.parse).then(upgrade(uri, locals)); // Run an upgrade!
+    promise = db.get(uri).then(JSON.parse).then(upgrade.init(uri, locals)); // Run an upgrade!
   }
 
   return promise.then(function (data) {
@@ -107,7 +106,8 @@ function get(uri, locals) {
       throw new Error('Client: Invalid data type for component at ' + uri + ' of ' + typeof data);
     }
 
-    return data;
+    // Strip _version from the data we return
+    return _.omit(data, '_version');
   });
 }
 

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -10,6 +10,7 @@ const _ = require('lodash'),
   timer = require('../timer'),
   glob = require('glob'),
   bluebird = require('bluebird'),
+  upgrade = require('./upgrade'),
   expect = require('chai').expect,
   winston = require('winston');
 
@@ -26,6 +27,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(files);
     sandbox.stub(winston);
     sandbox.stub(timer);
+    sandbox.stub(upgrade);
 
     lib.getPossibleTemplates.cache = new _.memoize.Cache();
     lib.getSchema.cache = new _.memoize.Cache();
@@ -487,6 +489,7 @@ describe(_.startCase(filename), function () {
 
     it('gets', function () {
       db.get.returns(bluebird.resolve('{}'));
+      upgrade.init.returns(bluebird.resolve('{}'));
       files.getComponentModule.withArgs('whatever').returns(null);
       return fn('domain.com/path/components/whatever');
     });
@@ -510,6 +513,7 @@ describe(_.startCase(filename), function () {
         renderSpy = sinon.stub();
 
       db.get.returns(Promise.resolve(JSON.stringify({a: 'b'})));
+      upgrade.init.returns(Promise.resolve({a: 'b'}));
       renderSpy.returns({ a: 'b' });
       files.getComponentModule.returns({render: renderSpy});
       return fn(ref).then(function () {

--- a/lib/services/upgrade.js
+++ b/lib/services/upgrade.js
@@ -1,0 +1,180 @@
+/* eslint max-params: [2, 5] */
+'use strict';
+
+const _ = require('lodash'),
+  db = require('./db'),
+  bluebird = require('bluebird'),
+  components = require('./components'),
+  files = require('../files'),
+  path = require('path');
+
+/**
+ * Just do a quick sort, lowest to highest.
+ *
+ * @param  {Number} a
+ * @param  {Number} b
+ * @return {Number}
+ */
+function sortNumber(a, b) {
+  return a - b;
+}
+
+/**
+ * Make an array of version numbers (that can include a decimal)
+ * and order them from least to greatest. The numbers are derived
+ * from the keys of the upgrade module that is required in.
+ *
+ * @param  {Object} upgrade
+ * @return {Array}
+ */
+function generateVersionArray(upgrade) {
+  return _.map(_.keys(upgrade), function (version) {
+    return parseFloat(version);
+  }).sort(sortNumber);
+}
+
+/**
+ * Iterate through the array of version transforms provided
+ * and determine which versions are valid to be run.
+ *
+ * -If the data has no current version but the schema declares
+ * one, then run it
+ * - If the current schema version is greater than the current
+ * version AND the tranform version is greater than the current
+ * version, run it.
+ *
+ * @param  {Number} schemaVersion
+ * @param  {Number} currentVersion
+ * @param  {Object} upgradeFile
+ * @return {Array}
+ */
+function aggregateTransforms(schemaVersion, currentVersion, upgradeFile) {
+  var transformVersions = generateVersionArray(upgradeFile),
+    applicableVersions = [];
+
+  for (let i = 0; i < transformVersions.length; i++) {
+    let version = transformVersions[i];
+
+    if (!currentVersion && schemaVersion || schemaVersion >= version && version > currentVersion) {
+      applicableVersions.push(transformVersions[i]);
+    }
+  }
+
+  return applicableVersions;
+}
+
+/**
+ * We have a the transforms we need to perform, so let's
+ * reduce them into the final data object.
+ *
+ * @param  {Array}   transforms
+ * @param  {Object}  upgradeFile
+ * @param  {String}  ref
+ * @param  {Object}  data
+ * @param  {Object}  locals
+ * @return {Promise}
+ */
+function runTransforms(transforms, upgradeFile, ref, data, locals) {
+  return bluebird.reduce(transforms, function (acc, val) {
+    return bluebird.try(function () {
+      return upgradeFile[val](ref, acc, locals);
+    });
+  }, data).then(function (resp) {
+    // Assign the version number automatically
+    resp._version = transforms[transforms.length - 1];
+    return resp;
+  });
+}
+
+/**
+ * The data that was upgraded needs to be saved so that
+ * we never need to upgrade again. Send it to the DB before
+ * returning that data.
+ *
+ * @param  {String} uri
+ * @return {Function}
+ */
+function saveTransformedData(uri) {
+  return function (data) {
+    return db.put(uri, JSON.stringify(data))
+      .then(function () {
+        // If the Promise resolves it means we saved,
+        // so let's return the data
+        return data;
+      })
+      .catch(function (err) {
+        throw new Error(`Upgrading component ${uri} failed, could not save data`);
+        return err;
+      });
+  };
+}
+/**
+ * We know a upgrade needs to happen, so let's kick it off. If
+ * there is no upgrade file, return early cause we can't do anything.
+ *
+ * If it exists though, we need to find which transforms to perform,
+ * make them happen, save that new data and then send it back
+ *
+ * @param  {Number} schemaVersion
+ * @param  {Number} dataVersion
+ * @param  {String} ref
+ * @param  {Object} data
+ * @param  {Object} locals
+ * @return {Promise}
+ */
+function upgradeData(schemaVersion, dataVersion, ref, data, locals) {
+  const componentDir = files.getComponentPath(components.getName(ref)), // Get the component directory
+    upgradeFile = files.tryRequire(path.resolve(componentDir, 'upgrade')); // Grab the the upgrade.js file
+
+  var transforms = [];
+
+  // If no upgrade file exists, exit early
+  if (!upgradeFile) {
+    return bluebird.resolve(data);
+  }
+
+  // find all the transforms that have to be performed (object.keys)
+  transforms = aggregateTransforms(schemaVersion, dataVersion, upgradeFile);
+  // pass through the transform
+  return runTransforms(transforms, upgradeFile, ref, data, locals)
+    .then(saveTransformedData(ref));
+}
+
+/**
+ * Grab the schema for the component and check if the schema
+ * and data versions do not match. If they do we don't need
+ * to do anything, otherwise the upgrade process needs to be
+ * kicked off.
+ *
+ * @param  {String} ref
+ * @param  {Object} data
+ * @param  {Object} locals
+ * @return {Promise}
+ */
+function checkForUpgrade(ref, data, locals) {
+  return components.getSchema(ref)
+    .then(function (schema) {
+      // If version does not match what's in the data
+      if (schema._version && schema._version !== data._version) {
+        return upgradeData(schema._version, data._version, ref, data, locals);
+      }
+
+      return bluebird.resolve(data);
+    });
+}
+
+/**
+ * Upgrade entry point for passing in the ref and locals.
+ *
+ * @param  {Object} ref
+ * @param  {Object} locals
+ * @return {Function}
+ */
+function upgrade(ref, locals) {
+  return function (data) {
+    return checkForUpgrade(ref, data, locals);
+  };
+}
+
+module.exports = upgrade;
+module.exports.checkForUpgrade = checkForUpgrade;

--- a/lib/services/upgrade.js
+++ b/lib/services/upgrade.js
@@ -37,7 +37,7 @@ function generateVersionArray(upgrade) {
  * Iterate through the array of version transforms provided
  * and determine which versions are valid to be run.
  *
- * -If the data has no current version but the schema declares
+ * - If the data has no current version but the schema declares
  * one, then run it
  * - If the current schema version is greater than the current
  * version AND the tranform version is greater than the current
@@ -103,8 +103,7 @@ function saveTransformedData(uri) {
         return data;
       })
       .catch(function (err) {
-        throw new Error(`Upgrading component ${uri} failed, could not save data`);
-        return err;
+        throw err;
       });
   };
 }
@@ -135,6 +134,11 @@ function upgradeData(schemaVersion, dataVersion, ref, data, locals) {
 
   // find all the transforms that have to be performed (object.keys)
   transforms = aggregateTransforms(schemaVersion, dataVersion, upgradeFile);
+
+  // If no transforms need to be run, exit early
+  if (!transforms.length) {
+    return bluebird.resolve(data);
+  }
   // pass through the transform
   return runTransforms(transforms, upgradeFile, ref, data, locals)
     .then(saveTransformedData(ref));
@@ -155,8 +159,8 @@ function checkForUpgrade(ref, data, locals) {
   return components.getSchema(ref)
     .then(function (schema) {
       // If version does not match what's in the data
-      if (schema._version && schema._version !== data._version) {
-        return upgradeData(schema._version, data._version, ref, data, locals);
+      if (schema && schema._version && schema._version !== data._version) {
+        return module.exports.upgradeData(schema._version, data._version, ref, data, locals);
       }
 
       return bluebird.resolve(data);
@@ -171,10 +175,17 @@ function checkForUpgrade(ref, data, locals) {
  * @return {Function}
  */
 function upgrade(ref, locals) {
+
   return function (data) {
     return checkForUpgrade(ref, data, locals);
   };
 }
 
-module.exports = upgrade;
+
+module.exports.init = upgrade;
+module.exports.upgradeData = upgradeData;
+
+// For testing
 module.exports.checkForUpgrade = checkForUpgrade;
+module.exports.generateVersionArray = generateVersionArray;
+module.exports.aggregateTransforms = aggregateTransforms;

--- a/lib/services/upgrade.test.js
+++ b/lib/services/upgrade.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const _ = require('lodash'),
+  filename = __filename.split('/').pop().split('.').shift(),
+  lib = require('./' + filename),
+  sinon = require('sinon'),
+  db = require('./db'),
+  bluebird = require('bluebird'),
+  components = require('./components'),
+  files = require('../files'),
+  expect = require('chai').expect;
+
+function returnData(ref, data) {
+  return data;
+}
+
+function fakeUgrades() {
+  return {
+    1: returnData,
+    1.1: returnData,
+    1.5: returnData,
+    2: returnData
+  };
+}
+
+describe(_.startCase(filename), function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+
+    sandbox.stub(components);
+    sandbox.stub(files);
+    sandbox.stub(db);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('generateVersionArray', function () {
+    const fn = lib[this.title],
+      upgrade = fakeUgrades();
+
+    it('returns an array of versions from an object keys', function () {
+      expect(fn(upgrade)).to.eql([1, 1.1, 1.5, 2]);
+    });
+  });
+
+  describe('aggregateTransforms', function () {
+    const fn = lib[this.title],
+      upgrade = fakeUgrades();
+
+    it('works when schema version is defined and current version is not', function () {
+      expect(fn(2, undefined, upgrade)).to.eql([1, 1.1, 1.5, 2]);
+    });
+
+    it('returns only versions that are higher than its current version and less than the schema version', function () {
+      expect(fn(2, 1.1, upgrade)).to.eql([1.5, 2]);
+    });
+  });
+
+  describe('checkForUpgrade', function () {
+    const fn = lib[this.title];
+
+    it('calls the upgradeData function', function () {
+      components.getSchema.returns(bluebird.resolve({_version: 2, value: 'foo'}));
+
+      sandbox.stub(lib, 'upgradeData');
+
+      return fn('site/components/foo/instances/bar', {_version: 1, value: 'bar'})
+        .then(function () {
+          expect(lib.upgradeData.calledOnce).to.be.true;
+        });
+    });
+  });
+
+  describe('upgradeData', function () {
+    const fn = lib[this.title],
+      sampleData = {_version: 1, value: 'bar'};
+
+    it('does not try to run transforms if the versions are the same', function () {
+      files.getComponentPath.returns('/some/path');
+      files.tryRequire.returns(fakeUgrades());
+
+      return fn(1, 1, 'site/components/foo/instances/bar', sampleData)
+        .then(function () {
+          expect(db.put.calledOnce).to.be.false;
+        });
+    });
+
+    it('returns the data if no upgrade file exists', function () {
+      files.getComponentPath.returns('/some/path');
+      files.tryRequire.returns(undefined);
+
+      return fn(1, 1, 'site/components/foo/instances/bar', sampleData)
+        .then(function (resp) {
+          expect(resp).to.eql(sampleData);
+        });
+    });
+
+    it('runs transforms if they should be run', function () {
+      files.getComponentPath.returns('/some/path');
+      files.tryRequire.returns(fakeUgrades());
+      db.put.returns(bluebird.resolve());
+
+      return fn(2, 1, 'site/components/foo/instances/bar', sampleData)
+        .then(function (resp) {
+          expect(resp._version).to.equal(2);
+        });
+    });
+
+    it('returns an error if a save fails', function () {
+      files.getComponentPath.returns('/some/path');
+      files.tryRequire.returns(fakeUgrades());
+      db.put.returns(bluebird.reject(new Error('error msg')));
+
+      return fn(2, 1, 'site/components/foo/instances/bar', sampleData)
+        .catch(function (err) {
+          expect(err.message).to.equal('error msg');
+        });
+    });
+  });
+});

--- a/test/api/components/put.js
+++ b/test/api/components/put.js
@@ -184,7 +184,9 @@ describe(endpointName, function () {
 
       acceptsJsonBody(path, {name: 'invalid', id: 'valid'}, {}, 404, { code: 404, message: 'Not Found' });
       acceptsJsonBody(path, {name: 'valid', id: 'valid'}, data, 200, data);
-      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 200, data);
+
+      acceptsJsonBody(path, {name: 'missing', id: 'missing'}, data, 404, { code: 404, message: 'Not Found' });
+
       acceptsJsonBody(path, {name: 'valid'}, cascadingData(), 200, cascadingData());
 
       acceptsHtml(path, {name: 'invalid', id: 'valid'}, 404);


### PR DESCRIPTION
Implementation of #398 

When a component is requested we will run it through upgrades in order to keep data consistent with the schema ONLY under the following two conditions:

- A component uses a `model.js` *instead of* a `server.js`
- A component does not use a `model.js` *or* a `server.js`

We can't go any lower than this level because transforms may depend on the `locals` object available to users in both `model.js` and `server.js` operations. 

Also, `server.js` support will be deprecate in Amphora 4.0 and this is encouragement to upgrade to `model.js` modules.

## Implementation Details
- Only major/minor versions are supported
- Transforms are run in order of least to greatest, meaning you can reduce through all transforms.
- The `_version` property is stored in component data in the database but is not sent to the end user when requesting the instance data for a component
- Amphora will look for an `upgrade.js` file in a component directory. Functions exported from this module should be version numbers.