### PR TITLE
bug: pass locals to get

### DIFF
--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -55,7 +55,7 @@ function composePage(pageData, locals) {
   const layoutReference = pageData.layout,
     pageDataNoConf = references.omitPageConfiguration(pageData);
 
-  return components.get(layoutReference)
+  return components.get(layoutReference, locals)
     .then(layoutData => mapLayoutToPageData(pageDataNoConf, layoutData))
     .then(fullData => resolveComponentReferences(fullData, locals));
 }


### PR DESCRIPTION
Looks like an oversight but get is expecting locals as the second parameter https://github.com/slategroup/amphora/blob/8a51ba9b1de050eeec0ad288c103bce82fb645ea/lib/services/components.js#L16