### PR TITLE
Remove old passport dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
     "js-yaml": "^3.2.0",
     "lodash": "^4.14.2",
     "node-fetch": "^1.3.0",
-    "passport": "^0.3.2",
-    "passport-google-oauth": "^1.0.0",
-    "passport-http-header-token": "^1.1.0",
-    "passport-ldapauth": "^0.6.0",
-    "passport-slack": "0.0.6",
-    "passport-twitter": "^1.0.4",
     "template2env": "^1.0.4",
     "through2-filter": "^2.0.0",
     "vhost": "^3.0.0"


### PR DESCRIPTION
Authentication was moved to `amphora-auth` in https://github.com/slategroup/amphora/commit/a754321 but the devs forgot to remove the passport deps. These are not referenced anywhere in this repo. 

Our security software has been flagging `passport-twitter` as a vulnerability. This PR doesn't actually fix that issue because `passport-twitter` is wired into `amphora-auth`, but I figured it wouldn't hurt to remove it here.